### PR TITLE
Fix the features import drush command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIG-122: Fixed the features import drush command.
 
 ### Security
 

--- a/factory-hooks/db-update/site-update.sh
+++ b/factory-hooks/db-update/site-update.sh
@@ -37,7 +37,7 @@ DRUSH_CMD="drush10 --verbose --root=$docroot --uri=https://$domain"
 $DRUSH_CMD updatedb >> /var/log/sites/${AH_SITE_NAME}/logs/$(hostname -s)/drush-update.log
 
 # Run `drush features:import:all`.
-$DRUSH_CMD drush features:import:all --bundle=ecms --yes >> /var/log/sites/${AH_SITE_NAME}/logs/$(hostname -s)/drush-features.log
+$DRUSH_CMD features:import:all --bundle=ecms --yes >> /var/log/sites/${AH_SITE_NAME}/logs/$(hostname -s)/drush-features.log
 
 # Rebuild caches after features import.
 $DRUSH_CMD cache-rebuild >> /var/log/sites/${AH_SITE_NAME}/logs/$(hostname -s)/drush-cache.log


### PR DESCRIPTION
## Summary
After checking the drush commands, I noticed the extra drush call in the features import command. So, it was running `drush drush features:import:all` instead of `drush features:import:all`. 🤦

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | n/a
| Risk level | Low
| Relevant links | [RIG-122](https://thinkoomph.jira.com/browse/rig-122)
