### PR TITLE
Prepare for the 0.2.7 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ### Changed
 - RIG-6: Updated ecms_patternlab to 0.2.8.
+- RIG-6: Updated ecms_profile to 0.2.6.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
-- RIG-6: Updated ecms_patternlab to 0.2.8.
-- RIG-6: Updated ecms_profile to 0.2.6.
 
 ### Deprecated
 
@@ -21,6 +19,12 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ### Fixed
 
+### Security
+
+## [0.2.7] - 2020-12-01
+### Changed
+- RIG-6: Updated ecms_patternlab to 0.2.8.
+- RIG-6: Updated ecms_profile to 0.2.6.
 ### Security
 - RIG-157: Security Update: SA-CORE-2020-013
 
@@ -146,7 +150,9 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - Initial Release of the site
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/0.2.5...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/0.2.7...HEAD
+[0.2.7]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/0.2.6...0.2.7
+[0.2.6]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/0.2.5...0.2.6
 [0.2.5]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/0.2.4...0.2.5
 [0.2.4]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/0.2.3...0.2.4
 [0.2.3]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/0.2.2...0.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
+- RIG-6: Updated ecms_patternlab to 0.2.8.
 
 ### Deprecated
 
@@ -20,6 +21,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Fixed
 
 ### Security
+- RIG-157: Security Update: SA-CORE-2020-013
 
 ## [0.2.6] - 2020-11-25
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
         "drupal/mysql56": "^1.0",
         "drush/drush": "^10.0",
         "oomphinc/composer-installers-extender": "^2.0",
-        "rhodeislandecms/ecms_profile": "0.2.5",
+        "rhodeislandecms/ecms_profile": "0.2.6",
         "state-of-rhode-island-ecms/ecms_patternlab": "0.2.8",
         "zaporylie/composer-drupal-optimizations": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
         "drush/drush": "^10.0",
         "oomphinc/composer-installers-extender": "^2.0",
         "rhodeislandecms/ecms_profile": "0.2.5",
-        "state-of-rhode-island-ecms/ecms_patternlab": "0.2.7",
+        "state-of-rhode-island-ecms/ecms_patternlab": "0.2.8",
         "zaporylie/composer-drupal-optimizations": "^1.0"
     },
     "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "21b685842e4677f57a98d8c63086b34f",
+    "content-hash": "65714f2bfcfc3f8ee6a779d8db3f84dd",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2332,16 +2332,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "9.0.8",
+            "version": "9.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "67ec8d625bb29c4323bc34c680887bf4af0187e1"
+                "reference": "03d815cf785654d03cf39dd911c8ae53b2fdd6cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/67ec8d625bb29c4323bc34c680887bf4af0187e1",
-                "reference": "67ec8d625bb29c4323bc34c680887bf4af0187e1",
+                "url": "https://api.github.com/repos/drupal/core/zipball/03d815cf785654d03cf39dd911c8ae53b2fdd6cd",
+                "reference": "03d815cf785654d03cf39dd911c8ae53b2fdd6cd",
                 "shasum": ""
             },
             "require": {
@@ -2367,7 +2367,7 @@
                 "laminas/laminas-diactoros": "^2.1",
                 "laminas/laminas-feed": "^2.12",
                 "masterminds/html5": "^2.1",
-                "pear/archive_tar": "^1.4.9",
+                "pear/archive_tar": "^1.4.11",
                 "php": ">=7.3",
                 "psr/log": "^1.0",
                 "stack/builder": "^1.0",
@@ -2581,7 +2581,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
-            "time": "2020-11-17T22:05:11+00:00"
+            "time": "2020-11-26T00:53:25+00:00"
         },
         {
             "name": "drupal/core-composer-scaffold",
@@ -2670,16 +2670,16 @@
         },
         {
             "name": "drupal/core-recommended",
-            "version": "9.0.8",
+            "version": "9.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-recommended.git",
-                "reference": "26190ab57104b47d7c2a48a08b739abba4e31025"
+                "reference": "09a02abdc006bb447e67ea0486e4e81db6f49748"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/26190ab57104b47d7c2a48a08b739abba4e31025",
-                "reference": "26190ab57104b47d7c2a48a08b739abba4e31025",
+                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/09a02abdc006bb447e67ea0486e4e81db6f49748",
+                "reference": "09a02abdc006bb447e67ea0486e4e81db6f49748",
                 "shasum": ""
             },
             "require": {
@@ -2688,7 +2688,7 @@
                 "doctrine/annotations": "1.10.3",
                 "doctrine/lexer": "1.2.1",
                 "doctrine/reflection": "1.2.1",
-                "drupal/core": "9.0.8",
+                "drupal/core": "9.0.9",
                 "egulias/email-validator": "2.1.17",
                 "guzzlehttp/guzzle": "6.5.4",
                 "guzzlehttp/promises": "v1.3.1",
@@ -2699,7 +2699,7 @@
                 "laminas/laminas-stdlib": "3.2.1",
                 "laminas/laminas-zendframework-bridge": "1.0.4",
                 "masterminds/html5": "2.7.0",
-                "pear/archive_tar": "1.4.9",
+                "pear/archive_tar": "1.4.11",
                 "pear/console_getopt": "v1.4.3",
                 "pear/pear-core-minimal": "v1.10.10",
                 "pear/pear_exception": "v1.0.1",
@@ -2748,7 +2748,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Locked core dependencies; require this project INSTEAD OF drupal/core.",
-            "time": "2020-11-17T22:05:11+00:00"
+            "time": "2020-11-26T00:53:25+00:00"
         },
         {
             "name": "drupal/core-vendor-hardening",
@@ -7139,16 +7139,16 @@
         },
         {
             "name": "pear/archive_tar",
-            "version": "1.4.9",
+            "version": "1.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/Archive_Tar.git",
-                "reference": "c5b00053770e1d72128252c62c2c1a12c26639f0"
+                "reference": "17d355cb7d3c4ff08e5729f29cd7660145208d9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/c5b00053770e1d72128252c62c2c1a12c26639f0",
-                "reference": "c5b00053770e1d72128252c62c2c1a12c26639f0",
+                "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/17d355cb7d3c4ff08e5729f29cd7660145208d9d",
+                "reference": "17d355cb7d3c4ff08e5729f29cd7660145208d9d",
                 "shasum": ""
             },
             "require": {
@@ -7201,7 +7201,7 @@
                 "archive",
                 "tar"
             ],
-            "time": "2019-12-04T10:17:28+00:00"
+            "time": "2020-11-19T22:10:24+00:00"
         },
         {
             "name": "pear/console_getopt",
@@ -7949,11 +7949,11 @@
         },
         {
             "name": "state-of-rhode-island-ecms/ecms_patternlab",
-            "version": "0.2.7",
+            "version": "0.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/State-of-Rhode-Island-eCMS/ecms_patternlab.git",
-                "reference": "869b4770fb2c5f0eceb5feb6351c91cbbe80c148"
+                "reference": "0c20c03b8db89b28ac5b826e928279b88a60b53f"
             },
             "type": "pattern-lab",
             "license": [
@@ -7967,7 +7967,7 @@
                 }
             ],
             "description": "Pattern Lab for the State of Rhode Island's eCMS system",
-            "time": "2020-11-25T18:13:13+00:00"
+            "time": "2020-12-01T19:42:12+00:00"
         },
         {
             "name": "symfony-cmf/routing",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "65714f2bfcfc3f8ee6a779d8db3f84dd",
+    "content-hash": "e8016fdb5b865ec385e279a5115019b7",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7703,11 +7703,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "0.2.5",
+            "version": "0.2.6",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "e696790758990b90958630edd5690851bfdb79cb"
+                "reference": "6a77e9765c2be45fcddb1e4c58abdfbd4192f441"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -7804,7 +7804,8 @@
                         "3142997 - D9 readiness": "https://www.drupal.org/files/issues/2020-06-05/3142997-20.patch"
                     },
                     "drupal_git/migration_tools": {
-                        "3148135 - D9 readiness": "https://www.drupal.org/files/issues/2020-11-17/automated-d9-compatibility-fixes-3148135-5.patch"
+                        "3148135 - D9 readiness": "https://www.drupal.org/files/issues/2020-11-17/automated-d9-compatibility-fixes-3148135-5.patch",
+                        "3163830 - Fatal Error: Call to undefined function drush_print()": "https://www.drupal.org/files/issues/2020-08-06/migration_tools-drush-10-compatibility-13778991-3.patch"
                     },
                     "drupal_git/migrate_google_sheets": {
                         "3138999 - D9 readiness": "https://www.drupal.org/files/issues/2020-11-17/Drupal-9-readiness-3138999-6.patch"
@@ -7841,7 +7842,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2020-11-25T18:17:26+00:00"
+            "time": "2020-12-01T20:14:42+00:00"
         },
         {
             "name": "simshaun/recurr",


### PR DESCRIPTION
## Summary
This updates:
- ecms_patternlab repo to 0.2.8.
- ecms_profile to 0.2.6
- Drupal core to 9.0.9
and prepares the changelog for the 0.2.7 release.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | yes
| Risk level | Medium
| Relevant links | [RIG-6](https://thinkoomph.jira.com/browse/rig-6)
