### PR TITLE
Hot fix drush deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- Fixed deployment error due to https redirect and CLI conflict.
 
 ### Security
 

--- a/factory-hooks/pre-settings-php/protocol.php
+++ b/factory-hooks/pre-settings-php/protocol.php
@@ -19,8 +19,10 @@ function isSecure(): bool {
 
 // Redirect to the secure version.
 if (($_ENV['AH_SITE_ENVIRONMENT'] === "01live" || $_ENV['AH_SITE_ENVIRONMENT'] === "01dev") && !isSecure()) {
-  header('HTTP/1.0 301 Moved Permanently');
-  header('Location: https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
-  exit();
+  if (PHP_SAPI !== 'cli') {
+    header('HTTP/1.0 301 Moved Permanently');
+    header('Location: https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
+    exit();
+  }
 }
 


### PR DESCRIPTION
## Summary
Hot fix for the deployment error on the live environment. Drush commands were failing, causing the sites to not be available.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | no
| Risk level | Low
| Relevant links | [RIG-6](https://thinkoomph.jira.com/browse/rig-6)
