### PR TITLE
Site Factory install error for new sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIG-165: Unable to install a new site.
 
 ### Security
 

--- a/factory-hooks/pre-settings-php/protocol.php
+++ b/factory-hooks/pre-settings-php/protocol.php
@@ -2,19 +2,22 @@
 
 declare(strict_types = 1);
 
-/**
- * Test if the current request is encrypted.
- * @return bool
- */
-function isSecure(): bool {
-  $isSecure = FALSE;
-  if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') {
-    $isSecure = TRUE;
+// Check if the isSecure function exists before generating it.
+if (!function_exists('isSecure')) {
+  /**
+   * Test if the current request is encrypted.
+   * @return bool
+   */
+  function isSecure(): bool {
+    $isSecure = FALSE;
+    if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') {
+      $isSecure = TRUE;
+    }
+    elseif (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https' || !empty($_SERVER['HTTP_X_FORWARDED_SSL']) && $_SERVER['HTTP_X_FORWARDED_SSL'] === 'on') {
+      $isSecure = TRUE;
+    }
+    return $isSecure;
   }
-  elseif (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https' || !empty($_SERVER['HTTP_X_FORWARDED_SSL']) && $_SERVER['HTTP_X_FORWARDED_SSL'] === 'on') {
-    $isSecure = TRUE;
-  }
-  return $isSecure;
 }
 
 // Redirect to the secure version.


### PR DESCRIPTION
## Summary
This wraps the `isSecure()` function in a `function_exists()` to ensure it only is loaded once. This should allow Site Factory to create new sites and stop throwing this fatal:

```
PHP Fatal error:  Cannot redeclare isSecure() (previously declared in /mnt/www/html/riecms01dev/factory-hooks/pre-settings-php/protocol.php:10) in /mnt/www/html/riecms01dev/factory-hooks/pre-settings-php/protocol.php on line 18
```

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-165](https://thinkoomph.jira.com/browse/rig-165)
