### PR TITLE
Update and prepare for the 0.3.5 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,16 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
-- RIG-185: Added the webform library dependencies.
 
 ### Security
+
+## [0.3.5] - 2020-12-14
+### Changed
+- RIG-6: Updated ecms_patternlab to 0.3.5.
+- RIG-6: Updated ecms_profile to 0.3.3.
+
+### Fixed
+- RIG-185: Added the webform library dependencies.
 
 ## [0.3.4] - 2020-12-12
 ### Changed
@@ -190,7 +197,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - Initial Release of the site
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/0.3.4...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/0.3.5...HEAD
+[0.3.5]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/0.3.4...0.3.5
 [0.3.4]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/0.3.3...0.3.4
 [0.3.3]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/0.3.2...0.3.3
 [0.3.2]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/0.3.1...0.3.2

--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
         "drupal/mysql56": "^1.0",
         "drush/drush": "^10.0",
         "oomphinc/composer-installers-extender": "^2.0",
-        "rhodeislandecms/ecms_profile": "0.3.2",
+        "rhodeislandecms/ecms_profile": "0.3.3",
         "state-of-rhode-island-ecms/ecms_patternlab": "0.3.5",
         "wikimedia/composer-merge-plugin": "dev-master",
         "zaporylie/composer-drupal-optimizations": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -79,9 +79,9 @@
         "drush/drush": "^10.0",
         "oomphinc/composer-installers-extender": "^2.0",
         "rhodeislandecms/ecms_profile": "0.3.2",
-        "state-of-rhode-island-ecms/ecms_patternlab": "0.3.4",
-        "zaporylie/composer-drupal-optimizations": "^1.0",
-        "wikimedia/composer-merge-plugin": "dev-master"
+        "state-of-rhode-island-ecms/ecms_patternlab": "0.3.5",
+        "wikimedia/composer-merge-plugin": "dev-master",
+        "zaporylie/composer-drupal-optimizations": "^1.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "552952baae2c3313db23d844c4180243",
+    "content-hash": "7f38d43b331e5c6a9e14bc7a15aadb64",
     "packages": [
         {
             "name": "algolia/places",
@@ -8348,11 +8348,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "0.3.2",
+            "version": "0.3.3",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "af29ffda015e02203d2fc9f57dd5dc18d2286737"
+                "reference": "d843ea9ec1265083b0a24fccccc4835e6dc44414"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -8493,7 +8493,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2020-12-12T15:58:34+00:00"
+            "time": "2020-12-14T15:53:38+00:00"
         },
         {
             "name": "signature_pad/signature_pad",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4fd16a9df72437635d000aa947146cf8",
+    "content-hash": "552952baae2c3313db23d844c4180243",
     "packages": [
         {
             "name": "algolia/places",
@@ -8616,11 +8616,11 @@
         },
         {
             "name": "state-of-rhode-island-ecms/ecms_patternlab",
-            "version": "0.3.4",
+            "version": "0.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/State-of-Rhode-Island-eCMS/ecms_patternlab.git",
-                "reference": "f73ceec8c47c19b51057f759554614666c01e6fa"
+                "reference": "63b70b5310188b14059a0cecf324ffca0502b547"
             },
             "type": "pattern-lab",
             "license": [
@@ -8634,7 +8634,7 @@
                 }
             ],
             "description": "Pattern Lab for the State of Rhode Island's eCMS system",
-            "time": "2020-12-11T17:13:43+00:00"
+            "time": "2020-12-14T15:41:28+00:00"
         },
         {
             "name": "svg-pan-zoom/svg-pan-zoom",


### PR DESCRIPTION
## Summary
This brings the ecms_patternlab to version 0.3.5, the ecms_profile to version 0.3.3 and prepares the changelog for the 0.3.5 tag.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | no
| Risk level | Low
| Relevant links | [RIG-6](https://thinkoomph.jira.com/browse/rig-6)
