### PR TITLE
Prepare for the 1.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ### Security
 
+## [1.0.1] - 2020-12-16
+### Changed
+- RIG-6: Updated ecms_profile to 0.3.8.
+
 ## [1.0.0] - 2020-12-16
 ### Changed
 - RIG-6: Updated ecms_patternlab to 0.3.9.
@@ -223,7 +227,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - Initial Release of the site
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.0.0...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.0.1...HEAD
+[1.0.1]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/0.3.9...1.0.0
 [0.3.9]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/0.3.8...0.3.9
 [0.3.8]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/0.3.7...0.3.8

--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
         "drupal/mysql56": "^1.0",
         "drush/drush": "^10.0",
         "oomphinc/composer-installers-extender": "^2.0",
-        "rhodeislandecms/ecms_profile": "0.3.7",
+        "rhodeislandecms/ecms_profile": "0.3.8",
         "state-of-rhode-island-ecms/ecms_patternlab": "0.3.9",
         "wikimedia/composer-merge-plugin": "dev-master",
         "zaporylie/composer-drupal-optimizations": "^1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9b9e403bcd757ece0b04f7db0df33a0c",
+    "content-hash": "419e65f3414ccac2cd84e85bbc1c9f45",
     "packages": [
         {
             "name": "algolia/places",
@@ -8424,11 +8424,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "0.3.7",
+            "version": "0.3.8",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "969f33cbb2165237ba599b4d3bde2d0cc008d214"
+                "reference": "4fa8498756697e3e68af3984678dc3169654ff0a"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -8570,7 +8570,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2020-12-16T14:07:13+00:00"
+            "time": "2020-12-16T19:37:02+00:00"
         },
         {
             "name": "signature_pad/signature_pad",


### PR DESCRIPTION
## Summary
This brings the ecms_profile to 0.3.8 and updates the changelog for 1.0.1.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | no
| Risk level | Low
| Relevant links | [RIG-6](https://thinkoomph.jira.com/browse/rig-6)
