### PR TITLE
Prepare changelog and update dependencies for release 1.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIGA-297: Upgrade drupal/search_api_solr 4.2.7 => 4.2.8.
 - RIGA-297: Upgrade drupal/token 1.10.0 => 1.11.0.
 - RIGA-297: Upgrade drupal/jsonapi_extras 3.20.0 => 3.21.0.
+- RIGA-6: Updated ecms_profile to 0.9.12.
 
 ## [1.7.4] - 2022-07-28
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,6 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
-- RIGA-297: Upgrade drupal/acsf_duplication 2.68.0 => 2.72.0.
-- RIGA-297: Upgrade drupal/acsf_theme 2.68.0 => 2.72.0.
-- RIGA-297: Upgrade drupal/acsf_variables 2.68.0 => 2.72.0.
-- RIGA-297: Upgrade drupal/memcache 2.3.0 => 2.4.0.
-- RIGA-297: Upgrade drupal/search_api 1.23.0 => 1.25.0.
-- RIGA-297: Upgrade drupal/search_api_solr 4.2.7 => 4.2.8.
-- RIGA-297: Upgrade drupal/token 1.10.0 => 1.11.0.
-- RIGA-297: Upgrade drupal/jsonapi_extras 3.20.0 => 3.21.0.
-- RIGA-297: Update line numbers of htaccess patch.
 
 ### Deprecated
 
@@ -29,6 +20,20 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Fixed
 
 ### Security
+
+## [1.7.5] - 2022-08-11
+### Changed
+- RIGA-282: Update drupal/core 9.3.19 => 9.4.5.
+- RIGA-282: Update core patch for issue 1356276.
+- RIGA-282: Update line numbers of htaccess patch.
+- RIGA-297: Upgrade drupal/acsf_duplication 2.68.0 => 2.72.0.
+- RIGA-297: Upgrade drupal/acsf_theme 2.68.0 => 2.72.0.
+- RIGA-297: Upgrade drupal/acsf_variables 2.68.0 => 2.72.0.
+- RIGA-297: Upgrade drupal/memcache 2.3.0 => 2.4.0.
+- RIGA-297: Upgrade drupal/search_api 1.23.0 => 1.25.0.
+- RIGA-297: Upgrade drupal/search_api_solr 4.2.7 => 4.2.8.
+- RIGA-297: Upgrade drupal/token 1.10.0 => 1.11.0.
+- RIGA-297: Upgrade drupal/jsonapi_extras 3.20.0 => 3.21.0.
 
 ## [1.7.4] - 2022-07-28
 ### Changed
@@ -658,7 +663,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - Initial Release of the site.
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.7.4...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.7.5...HEAD
+[1.7.5]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.7.4...1.7.5
 [1.7.4]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.7.3...1.7.4
 [1.7.3]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.7.2...1.7.3
 [1.7.2]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.7.1...1.7.2

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
         "php": ">=7.4",
-        "rhodeislandecms/ecms_profile": "dev-RIGA-6/docs-update",
+        "rhodeislandecms/ecms_profile": "0.9.12",
         "state-of-rhode-island-ecms/ecms_patternlab": "0.7.1",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3edad6b319cd274ca91e12f0eba973a7",
+    "content-hash": "ed3ca78919dd42d82c593d2fe60fc9e1",
     "packages": [
         {
             "name": "algolia/places",
@@ -12062,11 +12062,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "dev-RIGA-6/docs-update",
+            "version": "0.9.12",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "8b8ef77da676a73f440161ce3bf46882bfd9bf4f"
+                "reference": "96c7e1d6fa8853d60f63fbec141ff9fa13990187"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -12229,7 +12229,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2022-08-09T13:29:09+00:00"
+            "time": "2022-08-10T17:09:26+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",
@@ -18104,9 +18104,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "rhodeislandecms/ecms_profile": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
## [1.7.5] - 2022-08-11
### Changed
- RIGA-282: Update drupal/core 9.3.19 => 9.4.5.
- RIGA-282: Update core patch for issue 1356276.
- RIGA-282: Update line numbers of htaccess patch.
- RIGA-297: Upgrade drupal/acsf_duplication 2.68.0 => 2.72.0.
- RIGA-297: Upgrade drupal/acsf_theme 2.68.0 => 2.72.0.
- RIGA-297: Upgrade drupal/acsf_variables 2.68.0 => 2.72.0.
- RIGA-297: Upgrade drupal/memcache 2.3.0 => 2.4.0.
- RIGA-297: Upgrade drupal/search_api 1.23.0 => 1.25.0.
- RIGA-297: Upgrade drupal/search_api_solr 4.2.7 => 4.2.8.
- RIGA-297: Upgrade drupal/token 1.10.0 => 1.11.0.
- RIGA-297: Upgrade drupal/jsonapi_extras 3.20.0 => 3.21.0.
- RIGA-6: Updated ecms_profile to 0.9.12.