### PR TITLE
Prepare CHANGELOG and update dependencies for 1.7.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,6 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
-- RIGA-308: Upgrade drupal/acquia_connector 3.0.4 => 3.0.5.
-- RIGA-308: Upgrade drupal/acsf 2.72 => 2.73.
-- RIGA-308: Upgrade drupal/memcache 2.4.0 => 2.5.0.
-- RIGA-308: Upgrade drupal/metatag 1.19.0 => 1.21.0.
-- RIGA-308: Upgrade drupal/pathauto 1.10.0 => 1.11.0.
-- RIGA-308: Upgrade drupal/purge 3.2.0 => 3.3.0.
-- RIGA-308: Upgrade drupal/redirect 1.7.0 => 1.8.0.
 
 ### Deprecated
 
@@ -27,6 +20,17 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Fixed
 
 ### Security
+
+## [1.7.6] - 2022-09-15
+### Changed
+- RIGA-308: Upgrade drupal/acquia_connector 3.0.4 => 3.0.5.
+- RIGA-308: Upgrade drupal/acsf 2.72 => 2.73.
+- RIGA-308: Upgrade drupal/memcache 2.4.0 => 2.5.0.
+- RIGA-308: Upgrade drupal/metatag 1.19.0 => 1.21.0.
+- RIGA-308: Upgrade drupal/pathauto 1.10.0 => 1.11.0.
+- RIGA-308: Upgrade drupal/purge 3.2.0 => 3.3.0.
+- RIGA-308: Upgrade drupal/redirect 1.7.0 => 1.8.0.
+- RIGA-6: Updated ecms_profile to 0.9.13.
 
 ## [1.7.5] - 2022-08-11
 ### Changed
@@ -671,7 +675,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - Initial Release of the site.
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.7.5...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.7.6...HEAD
+[1.7.6]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.7.5...1.7.6
 [1.7.5]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.7.4...1.7.5
 [1.7.4]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.7.3...1.7.4
 [1.7.3]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.7.2...1.7.3

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
         "php": ">=7.4",
-        "rhodeislandecms/ecms_profile": "dev-RIGA-308/september-module-updates",
+        "rhodeislandecms/ecms_profile": "0.9.13",
         "state-of-rhode-island-ecms/ecms_patternlab": "0.7.1",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2b2deb150dbed1df3e8d9e9ea6453e4",
+    "content-hash": "e2ae6247e38a142594bb38f735592087",
     "packages": [
         {
             "name": "algolia/places",
@@ -12118,11 +12118,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "dev-RIGA-308/september-module-updates",
+            "version": "0.9.13",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "6507ada62ddd535de48dc3daa5ab8118ab8e16f0"
+                "reference": "27057b577153619868922ea0ebe8655a9bb1315b"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -12285,7 +12285,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2022-09-13T16:04:04+00:00"
+            "time": "2022-09-14T20:20:42+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",
@@ -18160,9 +18160,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "rhodeislandecms/ecms_profile": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
## [1.7.6] - 2022-09-15
### Changed
- RIGA-308: Upgrade drupal/acquia_connector 3.0.4 => 3.0.5.
- RIGA-308: Upgrade drupal/acsf 2.72 => 2.73.
- RIGA-308: Upgrade drupal/memcache 2.4.0 => 2.5.0.
- RIGA-308: Upgrade drupal/metatag 1.19.0 => 1.21.0.
- RIGA-308: Upgrade drupal/pathauto 1.10.0 => 1.11.0.
- RIGA-308: Upgrade drupal/purge 3.2.0 => 3.3.0.
- RIGA-308: Upgrade drupal/redirect 1.7.0 => 1.8.0.
- RIGA-6: Updated ecms_profile to 0.9.13.