### PR TITLE
Prepare CHANGELOG and dependencies for 1.8.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
-- RIGA-333: Upgrading drupal/entity_reference_revisions 1.9.0 => 1.10.0.
 
 ### Deprecated
 
@@ -21,6 +20,11 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Fixed
 
 ### Security
+
+## [1.8.4] - 2022-12-08
+### Changed
+- RIGA-333: Upgrading drupal/entity_reference_revisions 1.9.0 => 1.10.0.
+- RIGA-6: Updated ecms_profile to 0.9.19.
 
 ## [1.8.3] - 2022-11-17
 ### Changed
@@ -728,7 +732,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - Initial Release of the site.
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.3...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.4...HEAD
+[1.8.4]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.3...1.8.4
 [1.8.3]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.2...1.8.3
 [1.8.2]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.1...1.8.2
 [1.8.1]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.0...1.8.1

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
         "php": ">=8.0",
-        "rhodeislandecms/ecms_profile": "dev-RIGA-333/december-contrib-module-updates",
+        "rhodeislandecms/ecms_profile": "0.9.19",
         "state-of-rhode-island-ecms/ecms_patternlab": "0.7.2",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "201bbe71d226d32fa5a1a118860f0ced",
+    "content-hash": "2af334f662d92d8380982d22ad93c057",
     "packages": [
         {
             "name": "algolia/places",
@@ -12210,11 +12210,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "dev-RIGA-333/december-contrib-module-updates",
+            "version": "0.9.19",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "42a2987f68490575a6746390cefee29a7f16124b"
+                "reference": "116b8ad1b9d8f0bc53f0a1942d6ce16b4f1f4060"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -12376,7 +12376,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2022-12-07T16:33:38+00:00"
+            "time": "2022-12-08T17:28:04+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",
@@ -18358,9 +18358,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "rhodeislandecms/ecms_profile": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
## [1.8.4] - 2022-12-08
### Changed
- RIGA-333: Upgrading drupal/entity_reference_revisions 1.9.0 => 1.10.0.
- RIGA-6: Updated ecms_profile to 0.9.19