### PR TITLE
Prepare CHANGELOG and dependencies for 1.8.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,6 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
-- RIGA-345: Upgrade drupal/admin_toolbar 3.2.1 => 3.3.0.
-- RIGA-345: Upgrade drupal/simple_oauth 5.2.0 => 5.2.3.
-- RIGA-345: Upgrade drupal/smart_date 3.5.1 => 3.6.1.
 
 ### Deprecated
 
@@ -23,6 +20,12 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Fixed
 
 ### Security
+
+## [1.8.5] - 2022-12-15
+### Changed
+- RIGA-345: Upgrade drupal/admin_toolbar 3.2.1 => 3.3.0.
+- RIGA-345: Upgrade drupal/simple_oauth 5.2.0 => 5.2.3.
+- RIGA-345: Upgrade drupal/smart_date 3.5.1 => 3.6.1.
 
 ## [1.8.4] - 2022-12-08
 ### Changed
@@ -735,7 +738,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - Initial Release of the site.
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.4...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.5...HEAD
+[1.8.5]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.4...1.8.5
 [1.8.4]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.3...1.8.4
 [1.8.3]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.2...1.8.3
 [1.8.2]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.1...1.8.2

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
         "php": ">=8.0",
-        "rhodeislandecms/ecms_profile": "0.9.19",
+        "rhodeislandecms/ecms_profile": "0.9.21",
         "state-of-rhode-island-ecms/ecms_patternlab": "0.7.2",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2af334f662d92d8380982d22ad93c057",
+    "content-hash": "cfef3b8791f4a110aecce657ad2029af",
     "packages": [
         {
             "name": "algolia/places",
@@ -2745,26 +2745,26 @@
         },
         {
             "name": "drupal/allowed_formats",
-            "version": "1.5.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/allowed_formats.git",
-                "reference": "8.x-1.5"
+                "reference": "2.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/allowed_formats-8.x-1.5.zip",
-                "reference": "8.x-1.5",
-                "shasum": "dbf61bee7aec87beaa2cf307c1d0d9d5b896328c"
+                "url": "https://ftp.drupal.org/files/projects/allowed_formats-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "ac6c6d398f303608ced7e9cd9d4556a728dc41f0"
             },
             "require": {
-                "drupal/core": "^8.8 || ^9"
+                "drupal/core": "^9.2 || ^10"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.5",
-                    "datestamp": "1648060331",
+                    "version": "2.0.0",
+                    "datestamp": "1669170410",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -12423,11 +12423,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "0.9.19",
+            "version": "0.9.21",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "116b8ad1b9d8f0bc53f0a1942d6ce16b4f1f4060"
+                "reference": "28b36ee093832c26ef2d9f85794218262f136592"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -12438,7 +12438,7 @@
                 "drupal/acsf": "2.73",
                 "drupal/address": "^1.8",
                 "drupal/admin_toolbar": "^3.1.0",
-                "drupal/allowed_formats": "^1.3",
+                "drupal/allowed_formats": "^2.0.0",
                 "drupal/asset_injector": "^2.7",
                 "drupal/auto_entitylabel": "^3.0@beta",
                 "drupal/better_exposed_filters": "^5.0",
@@ -12559,6 +12559,9 @@
                     },
                     "drupal_git/migrate_process_trim": {
                         "3141131 - D9 Readiness": "https://www.drupal.org/files/issues/2020-05-23/migrate_process_trim.1.x-dev.rector.patch"
+                    },
+                    "drupal/allowed_formats": {
+                        "2950548 - Default value for format dropdown missing": "https://www.drupal.org/files/issues/2022-02-02/2950548-allowed_formats-missing_default_value.patch"
                     }
                 },
                 "preserve-paths": [],
@@ -12589,7 +12592,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2022-12-08T17:28:04+00:00"
+            "time": "2022-12-15T16:42:06+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",


### PR DESCRIPTION
## [1.8.5] - 2022-12-15
### Changed
- RIGA-345: Upgrade drupal/admin_toolbar 3.2.1 => 3.3.0.
- RIGA-345: Upgrade drupal/simple_oauth 5.2.0 => 5.2.3.
- RIGA-345: Upgrade drupal/smart_date 3.5.1 => 3.6.1.