### PR TITLE
Add menu force module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIGA-354: Install drupal/menu_force 1.2.0.
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
         }
     ],
     "require": {
+        "php": ">=8.0",
         "behat/mink": "^1.8",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.6",
@@ -63,10 +64,10 @@
         "drupal/core-project-message": "^9",
         "drupal/core-recommended": "^9.1.8",
         "drupal/core-vendor-hardening": "^9",
+        "drupal/menu_force": "^1.2",
         "drush/drush": "^10.0",
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
-        "php": ">=8.0",
         "rhodeislandecms/ecms_profile": "0.9.21",
         "state-of-rhode-island-ecms/ecms_patternlab": "0.7.2",
         "wikimedia/composer-merge-plugin": "^2.0.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cfef3b8791f4a110aecce657ad2029af",
+    "content-hash": "86d99941706639ca2b061c64afce6aeb",
     "packages": [
         {
             "name": "algolia/places",
@@ -6171,6 +6171,58 @@
             "homepage": "https://www.drupal.org/project/menu_block",
             "support": {
                 "source": "https://git.drupalcode.org/project/menu_block"
+            }
+        },
+        {
+            "name": "drupal/menu_force",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/menu_force.git",
+                "reference": "8.x-1.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/menu_force-8.x-1.2.zip",
+                "reference": "8.x-1.2",
+                "shasum": "96036cf057002223ee08d1f03e494cbad25439ac"
+            },
+            "require": {
+                "drupal/core": "^8.7.7 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.2",
+                    "datestamp": "1593463689",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "BarisW",
+                    "homepage": "https://www.drupal.org/user/107229"
+                },
+                {
+                    "name": "perennial.sky",
+                    "homepage": "https://www.drupal.org/user/2622667"
+                },
+                {
+                    "name": "scuba_fly",
+                    "homepage": "https://www.drupal.org/user/953390"
+                }
+            ],
+            "description": "Makes sure a node gets added to the menu system on specific content types",
+            "homepage": "https://www.drupal.org/project/menu_force",
+            "support": {
+                "source": "https://git.drupalcode.org/project/menu_force"
             }
         },
         {


### PR DESCRIPTION
<!-- INSTRUCTIONS
- Please use a meaningful pull request title which does not include the issue
  key or branch name.
- Please apply meaningful GitHub Labels to your pull request such as: PHP,
  Twig, SCSS, JS, etc.
- Please make sure you've reviewed the "Files changed" tab before opening this
  PR to ensure it includes what you expect (and nothing more) and adheres to
  our coding standards.
- Browser requirements can be found in docs/browser-requirements.md from the
  root of the project.
-->

## Summary
<!-- Include a summary of your changes that expands upon the title. -->
Installs drupal/menu_force 1.2.0 using Composer, so it will be available to enable by site admins.
https://www.drupal.org/project/menu_force

Does NOT enable module in Drupal by default, this must be done at Extend UI `/admin/modules`

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIGA-354](https://thinkoomph.jira.com/browse/RIGA-354)
