### PR TITLE
Prepare CHANGELOG and dependencies for 1.8.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
-- RIGA-363: Install drupal/ckeditor 1.0.1.
-- RIGA-363: Install drupal/ckeditor_entity_link 1.3.0.
 
 ### Changed
-- RIGA-364: Upgrade drupal/smart_date 3.6.1 => 4.0.0-alpha3.
-- RIGA-364: Upgrade drupal/jquery_ui_datepicker 1.2.0 => 1.4.0.
-- RIGA-364: Upgrade drupal/jquery_ui_touch_punch 1.0.0 => 1.1.0.
-- RIGA-364: Upgrade drupal/jsonapi_extras 3.21.0 => 3.23.0.
-- RIGA-364: Upgrade drupal/address 1.10.0 => 1.11.0.
 
 ### Deprecated
 
@@ -27,6 +20,19 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Fixed
 
 ### Security
+
+## [1.8.9] - 2023-03-09
+### Added
+- RIGA-363: Install drupal/ckeditor 1.0.1.
+- RIGA-363: Install drupal/ckeditor_entity_link 1.3.0.
+
+### Changed
+- RIGA-6: Update ecms_profile => 0.9.23.
+- RIGA-364: Upgrade drupal/smart_date 3.6.1 => 4.0.0-alpha3.
+- RIGA-364: Upgrade drupal/jquery_ui_datepicker 1.2.0 => 1.4.0.
+- RIGA-364: Upgrade drupal/jquery_ui_touch_punch 1.0.0 => 1.1.0.
+- RIGA-364: Upgrade drupal/jsonapi_extras 3.21.0 => 3.23.0.
+- RIGA-364: Upgrade drupal/address 1.10.0 => 1.11.0.
 
 ## [1.8.8] - 2023-02-09
 ### Changed
@@ -776,7 +782,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - Initial Release of the site.
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.8...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.9...HEAD
+[1.8.9]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.8...1.8.9
 [1.8.8]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.7...1.8.8
 [1.8.7]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.6...1.8.7
 [1.8.6]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.5...1.8.6

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "drush/drush": "^10.0",
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
-        "rhodeislandecms/ecms_profile": "dev-RIGA-364/march-contrib-updates",
+        "rhodeislandecms/ecms_profile": "0.9.23",
         "state-of-rhode-island-ecms/ecms_patternlab": "0.7.2",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9331e2e9a4a71f0468e4ec00a0ce90db",
+    "content-hash": "e81e52f919c7ca0b02b73c7709daa121",
     "packages": [
         {
             "name": "acquia/http-hmac-php",
@@ -12942,11 +12942,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "dev-RIGA-364/march-contrib-updates",
+            "version": "0.9.23",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "2ca1744751af66f99f6bef2799c1349ea14244c1"
+                "reference": "28e2ea883284a4b6a1fb2153874f07c59532efd1"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -13113,7 +13113,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2023-03-04T04:20:37+00:00"
+            "time": "2023-03-09T10:12:38+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",
@@ -19099,9 +19099,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "rhodeislandecms/ecms_profile": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
## [1.8.9] - 2023-03-09
### Added
- RIGA-363: Install drupal/ckeditor 1.0.1.
- RIGA-363: Install drupal/ckeditor_entity_link 1.3.0.

### Changed
- RIGA-6: Update ecms_profile => 0.9.23.
- RIGA-364: Upgrade drupal/smart_date 3.6.1 => 4.0.0-alpha3.
- RIGA-364: Upgrade drupal/jquery_ui_datepicker 1.2.0 => 1.4.0.
- RIGA-364: Upgrade drupal/jquery_ui_touch_punch 1.0.0 => 1.1.0.
- RIGA-364: Upgrade drupal/jsonapi_extras 3.21.0 => 3.23.0.
- RIGA-364: Upgrade drupal/address 1.10.0 => 1.11.0.