### PR TITLE
Prepare CHANGELOG for 1.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,18 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
-- RIGA-369: Upgrade drupal/core 9.4.10 => 9.4.12.
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+### Security
+
+## [1.9.0] - 2023-03-16
+### Changed
+- RIGA-369: Upgrade drupal/core 9.4.10 => 9.4.12.
 
 ### Security
 - RIGA-369: Drupal core - Moderately critical - Information Disclosure - SA-CORE-2023-002.
@@ -786,7 +791,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - Initial Release of the site.
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.9...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.0...HEAD
+[1.9.0]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.9...1.9.0
 [1.8.9]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.8...1.8.9
 [1.8.8]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.7...1.8.8
 [1.8.7]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.6...1.8.7


### PR DESCRIPTION
## [1.9.0] - 2023-03-16
### Changed
- RIGA-369: Upgrade drupal/core 9.4.10 => 9.4.12.

### Security
- RIGA-369: Drupal core - Moderately critical - Information Disclosure - SA-CORE-2023-002.
- RIGA-369: Drupal core - Moderately critical - Information Disclosure - SA-CORE-2023-003.
- RIGA-369: Drupal core - Moderately critical - Access bypass - SA-CORE-2023-004.