### PR TITLE
Prepare CHANGELOG and dependencies for 1.9.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
-- RIGA-372: Install drupal/autologout 1.4.0.
-- RIGA-372: Add drupal/core patch, issue 3301239, comment 7.
 
 ### Changed
-- RIGA-371: Update user role permissions.
-- RIGA-373: Upgrade drupal/acquia_connector 4.0.1 => 4.0.4.
-- RIGA-373: Upgrade drupal/acquia_search 3.1.4 => 3.1.7.
-- RIGA-373: Upgrade drupal/search_api 1.28.0 => 1.29.0.
-- RIGA-373: Upgrade drupal/search_api_solr 4.2.9 => 4.2.10.
 
 ### Deprecated
 
@@ -27,6 +20,19 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Fixed
 
 ### Security
+
+## [1.9.2] - 2023-04-20
+### Added
+- RIGA-372: Install drupal/autologout 1.4.0.
+- RIGA-372: Add drupal/core patch, issue 3301239, comment 7.
+
+### Changed
+- RIGA-6: Update rhodeislandecms/ecms_profile => 0.9.25.
+- RIGA-371: Update user role permissions.
+- RIGA-373: Upgrade drupal/acquia_connector 4.0.1 => 4.0.4.
+- RIGA-373: Upgrade drupal/acquia_search 3.1.4 => 3.1.7.
+- RIGA-373: Upgrade drupal/search_api 1.28.0 => 1.29.0.
+- RIGA-373: Upgrade drupal/search_api_solr 4.2.9 => 4.2.10.
 
 ## [1.9.1] - 2023-04-06
 ### Changed
@@ -803,7 +809,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - Initial Release of the site.
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.1...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.2...HEAD
+[1.9.2]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.1...1.9.2
 [1.9.1]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.0...1.9.1
 [1.9.0]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.9...1.9.0
 [1.8.9]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.8...1.8.9

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "drush/drush": "^10.0",
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
-        "rhodeislandecms/ecms_profile": "dev-master",
+        "rhodeislandecms/ecms_profile": "0.9.25",
         "state-of-rhode-island-ecms/ecms_patternlab": "0.7.3",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "81eb37f594a438daeb2557bd1daff7fb",
+    "content-hash": "e24722a4f4a4f5bed5db8074fb339a01",
     "packages": [
         {
             "name": "acquia/http-hmac-php",
@@ -13038,11 +13038,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "dev-master",
+            "version": "0.9.25",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "4f554d61c33d2c1d8526d65493781f8954289731"
+                "reference": "33474ee61f759bfca57d554bee31855fd586db4d"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -13148,7 +13148,6 @@
                 "symfony/phpunit-bridge": "^5.1",
                 "weitzman/drupal-test-traits": "^1.5"
             },
-            "default-branch": true,
             "type": "drupal-profile",
             "extra": {
                 "patches": {
@@ -13214,7 +13213,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2023-04-19T09:31:24+00:00"
+            "time": "2023-04-20T03:46:11+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",
@@ -19202,9 +19201,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "rhodeislandecms/ecms_profile": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
## [1.9.2] - 2023-04-20
### Added
- RIGA-372: Install drupal/autologout 1.4.0.
- RIGA-372: Add drupal/core patch, issue 3301239, comment 7.

### Changed
- RIGA-6: Update rhodeislandecms/ecms_profile => 0.9.25.
- RIGA-371: Update user role permissions.
- RIGA-373: Upgrade drupal/acquia_connector 4.0.1 => 4.0.4.
- RIGA-373: Upgrade drupal/acquia_search 3.1.4 => 3.1.7.
- RIGA-373: Upgrade drupal/search_api 1.28.0 => 1.29.0.
- RIGA-373: Upgrade drupal/search_api_solr 4.2.9 => 4.2.10.