### PR TITLE
Prepare CHANGELOG and dependencies for 1.9.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,24 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
-- RIGA-379: Install nnnick/chartjs v3.9.1 locally to avoid CDN warning.
-- RIGA-380: Install drupal/feeds_ex 1.0.0-beta3.
 
 ### Changed
-- RIGA-379: Upgrade drupal/core 9.4.12 => 9.4.14.
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+### Security
+
+## [1.9.3] - 2023-04-27
+### Added
+- RIGA-379: Install nnnick/chartjs v3.9.1 locally to avoid CDN warning.
+- RIGA-380: Install drupal/feeds_ex 1.0.0-beta3.
+
+### Changed
+- RIGA-379: Upgrade drupal/core 9.4.12 => 9.4.14.
 
 ### Security
 - RIGA-379: Drupal core - Moderately critical - Access bypass - SA-CORE-2023-005.
@@ -813,7 +820,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - Initial Release of the site.
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.2...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.3...HEAD
+[1.9.3]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.2...1.9.3
 [1.9.2]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.1...1.9.2
 [1.9.1]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.0...1.9.1
 [1.9.0]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.8.9...1.9.0

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "nnnick/chartjs": "^3.9",
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
-        "rhodeislandecms/ecms_profile": "dev-RIGA-380/install-feeds_ex-module",
+        "rhodeislandecms/ecms_profile": "0.9.26",
         "state-of-rhode-island-ecms/ecms_patternlab": "0.7.3",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d749d2ab8093f318d5c52077bb452424",
+    "content-hash": "3dd5c596415c18a3ee8f6b069c540b4a",
     "packages": [
         {
             "name": "acquia/http-hmac-php",
@@ -13185,11 +13185,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "dev-RIGA-380/install-feeds_ex-module",
+            "version": "0.9.26",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "5deeac2803271815f7875414dcb269b1a1807d7c"
+                "reference": "5110ff57a8e98ec46381a09dacd3922e8d24f10b"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -13362,7 +13362,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2023-04-26T20:09:42+00:00"
+            "time": "2023-04-26T21:47:18+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",
@@ -19419,9 +19419,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "rhodeislandecms/ecms_profile": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
## [1.9.3] - 2023-04-27
### Added
- RIGA-379: Install nnnick/chartjs v3.9.1 locally to avoid CDN warning.
- RIGA-380: Install drupal/feeds_ex 1.0.0-beta3.

### Changed
- RIGA-379: Upgrade drupal/core 9.4.12 => 9.4.14.

### Security
- RIGA-379: Drupal core - Moderately critical - Access bypass - SA-CORE-2023-005.