### PR TITLE
Prepare CHANGELOG and dependencies for 1.9.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,6 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
-- RIGA-382: Upgrade drupal/captcha 1.9.0 => 1.10.0.
-- RIGA-382: Upgrade drupal/webform 6.1.3 => 6.1.4.
-- RIGA-382: Upgrade drupal/webform_views 5.0.0 => 5.1.0.
 
 ### Deprecated
 
@@ -23,6 +20,13 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Fixed
 
 ### Security
+
+## [1.9.4] - 2023-05-11
+### Changed
+- RIGA-6: Update rhodeislandecms/ecms_profile => 0.9.27.
+- RIGA-382: Upgrade drupal/captcha 1.9.0 => 1.10.0.
+- RIGA-382: Upgrade drupal/webform 6.1.3 => 6.1.4.
+- RIGA-382: Upgrade drupal/webform_views 5.0.0 => 5.1.0.
 
 ## [1.9.3] - 2023-04-27
 ### Added
@@ -823,7 +827,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - Initial Release of the site.
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.3...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.4...HEAD
+[1.9.4]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.3...1.9.4
 [1.9.3]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.2...1.9.3
 [1.9.2]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.1...1.9.2
 [1.9.1]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.0...1.9.1

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "nnnick/chartjs": "^3.9",
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
-        "rhodeislandecms/ecms_profile": "0.9.26",
+        "rhodeislandecms/ecms_profile": "0.9.27",
         "state-of-rhode-island-ecms/ecms_patternlab": "0.7.3",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3dd5c596415c18a3ee8f6b069c540b4a",
+    "content-hash": "cde5f11c872e70695f4911ef372bd239",
     "packages": [
         {
             "name": "acquia/http-hmac-php",
@@ -13188,11 +13188,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "0.9.26",
+            "version": "0.9.27",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "5110ff57a8e98ec46381a09dacd3922e8d24f10b"
+                "reference": "c432b24baab516585a8933a04edbd7c4ed745cb7"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -13365,7 +13365,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2023-04-26T21:47:18+00:00"
+            "time": "2023-05-11T04:22:24+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",


### PR DESCRIPTION
## [1.9.4] - 2023-05-11
### Changed
- RIGA-6: Update rhodeislandecms/ecms_profile => 0.9.27.
- RIGA-382: Upgrade drupal/captcha 1.9.0 => 1.10.0.
- RIGA-382: Upgrade drupal/webform 6.1.3 => 6.1.4.
- RIGA-382: Upgrade drupal/webform_views 5.0.0 => 5.1.0.