### PR TITLE
Prepare CHANGELOG and dependencies for 1.9.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,6 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
-- RIGA-387: Upgrade drupal/admin_toolbar 3.3.0 => 3.4.0.
-- RIGA-387: Upgrade drupal/bigmenu 2.0.0-rc2 => 2.0.0-rc3.
-- RIGA-387: Upgrade drupal/extlink 1.6.0 => 1.7.0.
 
 ### Deprecated
 
@@ -23,6 +20,13 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Fixed
 
 ### Security
+
+## [1.9.5] - 2023-05-25
+### Changed
+- RIGA-387: Upgrade drupal/admin_toolbar 3.3.0 => 3.4.0.
+- RIGA-387: Upgrade drupal/bigmenu 2.0.0-rc2 => 2.0.0-rc3.
+- RIGA-387: Upgrade drupal/extlink 1.6.0 => 1.7.0.
+- RIGA-387: Update rhodeislandecms/ecms_profile => 0.9.28.
 
 ## [1.9.4] - 2023-05-11
 ### Changed
@@ -830,7 +834,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - Initial Release of the site.
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.4...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.5...HEAD
+[1.9.5]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.4...1.9.5
 [1.9.4]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.3...1.9.4
 [1.9.3]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.2...1.9.3
 [1.9.2]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.1...1.9.2

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "nnnick/chartjs": "^3.9",
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
-        "rhodeislandecms/ecms_profile": "0.9.27",
+        "rhodeislandecms/ecms_profile": "0.9.28",
         "state-of-rhode-island-ecms/ecms_patternlab": "0.7.3",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cde5f11c872e70695f4911ef372bd239",
+    "content-hash": "99cd255f8e2dfa986418b152b1f9a59b",
     "packages": [
         {
             "name": "acquia/http-hmac-php",
@@ -13183,11 +13183,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "0.9.27",
+            "version": "0.9.28",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "c432b24baab516585a8933a04edbd7c4ed745cb7"
+                "reference": "5812f1fe1ebeb3b9e8ba36b565138438c0869de1"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -13360,7 +13360,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2023-05-11T04:22:24+00:00"
+            "time": "2023-05-25T07:33:10+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",


### PR DESCRIPTION
## [1.9.5] - 2023-05-25
### Changed
- RIGA-387: Upgrade drupal/admin_toolbar 3.3.0 => 3.4.0.
- RIGA-387: Upgrade drupal/bigmenu 2.0.0-rc2 => 2.0.0-rc3.
- RIGA-387: Upgrade drupal/extlink 1.6.0 => 1.7.0.
- RIGA-387: Update rhodeislandecms/ecms_profile => 0.9.28.