### PR TITLE
Fix missing Content Moderation workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
+- RIGA-395: Update dependencies with new config update hook.
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
         "nnnick/chartjs": "^3.9",
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
-        "rhodeislandecms/ecms_profile": "0.9.29",
+        "rhodeislandecms/ecms_profile": "dev-RIGA-395/fix-missing-moderation-workgflow",
         "state-of-rhode-island-ecms/ecms_patternlab": "0.7.3",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -13196,7 +13196,7 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "8ef8294240fbd3e8a941c235905a7410c6ed80be"
+                "reference": "9665e5203ffedefa53d38019ca51705699a7b4ef"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -13369,7 +13369,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2023-06-27T20:33:29+00:00"
+            "time": "2023-06-28T08:38:11+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "adccbd285dcf320c4940ed5ad0bde1f5",
+    "content-hash": "5747137a54ab08a700063db632302ea4",
     "packages": [
         {
             "name": "acquia/http-hmac-php",
@@ -13192,11 +13192,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "0.9.29",
+            "version": "dev-RIGA-395/fix-missing-moderation-workgflow",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "f21f3153802a6b42282acd48ab1f6f07de67cdcf"
+                "reference": "2fda2509d2e630f1e1d6e1e29153a372fa480eec"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -13369,7 +13369,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2023-06-14T16:57:27+00:00"
+            "time": "2023-06-27T07:48:14+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",
@@ -19425,7 +19425,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "rhodeislandecms/ecms_profile": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -13196,7 +13196,7 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "2fda2509d2e630f1e1d6e1e29153a372fa480eec"
+                "reference": "cc5c69a9b3c3c1cc28a219365050824e1f267045"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -13369,7 +13369,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2023-06-27T07:48:14+00:00"
+            "time": "2023-06-27T08:59:48+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -13196,7 +13196,7 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "159f21047fc203147b790ff6a49c6139b6d6e080"
+                "reference": "8ef8294240fbd3e8a941c235905a7410c6ed80be"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -13369,7 +13369,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2023-06-27T20:19:21+00:00"
+            "time": "2023-06-27T20:33:29+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -13196,7 +13196,7 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "0ff7e012c53e1de5df1995d8e7a6fcb04dedea04"
+                "reference": "159f21047fc203147b790ff6a49c6139b6d6e080"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -13369,7 +13369,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2023-06-27T09:14:21+00:00"
+            "time": "2023-06-27T20:19:21+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -13196,7 +13196,7 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "cc5c69a9b3c3c1cc28a219365050824e1f267045"
+                "reference": "0ff7e012c53e1de5df1995d8e7a6fcb04dedea04"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -13369,7 +13369,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2023-06-27T08:59:48+00:00"
+            "time": "2023-06-27T09:14:21+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",


### PR DESCRIPTION
<!-- INSTRUCTIONS
- Please use a meaningful pull request title which does not include the issue
  key or branch name.
- Please apply meaningful GitHub Labels to your pull request such as: PHP,
  Twig, SCSS, JS, etc.
- Please make sure you've reviewed the "Files changed" tab before opening this
  PR to ensure it includes what you expect (and nothing more) and adheres to
  our coding standards.
- Browser requirements can be found in docs/browser-requirements.md from the
  root of the project.
-->

## Summary
<!-- Include a summary of your changes that expands upon the title. -->
- The OLIS site lost the Content Moderation field from its Node edit forms.
- It looks like there were 2 issues: 
  - deleted workflow config, 
  - and a submit form which adds/removes Node types from the workflow, but which didn't actively do anything to update the node edit forms
- The work was done in the ecms_profile repo https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/pull/443 , and so this PR may not need to be merged, as long as there's an updated reference to the profile somewhere (e.g. in deploy branch PR).

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIGA-395](https://thinkoomph.jira.com/browse/RIGA-395)