### PR TITLE
Update CHANGELOG and dependencies for release 1.9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ### Security
 
+## [1.9.8] - 2023-06-29
+### Changed
+- RIGA-6: Update rhodeislandecms/ecms_profile => 0.9.30.
+
 ## [1.9.7] - 2023-06-22
 ### Changed
 - RIGA-397: Upgrade drupal/office_hours 1.7.0 => 1.11.0.

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
         "nnnick/chartjs": "^3.9",
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
-        "rhodeislandecms/ecms_profile": "0.9.29",
+        "rhodeislandecms/ecms_profile": "0.9.30",
         "state-of-rhode-island-ecms/ecms_patternlab": "0.7.3",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "adccbd285dcf320c4940ed5ad0bde1f5",
+    "content-hash": "47ee559661890084943c5b1b5486293d",
     "packages": [
         {
             "name": "acquia/http-hmac-php",
@@ -13192,11 +13192,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "0.9.29",
+            "version": "0.9.30",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "f21f3153802a6b42282acd48ab1f6f07de67cdcf"
+                "reference": "6b1512aba5dfa199bc5e9bcb33a3db82171ca723"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -13369,7 +13369,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2023-06-14T16:57:27+00:00"
+            "time": "2023-06-29T03:23:50+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",


### PR DESCRIPTION
## [1.9.8] - 2023-06-29
### Changed
- RIGA-6: Update rhodeislandecms/ecms_profile => 0.9.30.