### PR TITLE
Prepare CHANGELOG and dependencies for release 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ### Security
 
+## [1.10.0] - 2023-07-13
+### Changed
+- RIGA-6: Upgrade to 1.10.0 to reflect drupal/core 9.4.x => 9.5.x upgrade.
+- RIGA-6: Update rhodeislandecms/ecms_profile 0.9.31 => 0.10.0.
+
 ## [1.9.9] - 2023-07-13
 ### Changed
 - RIGA-6: Update rhodeislandecms/ecms_profile => 0.9.31.
@@ -868,7 +873,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - Initial Release of the site.
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.9...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.0...HEAD
+[1.10.0]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.9...1.10.0
 [1.9.9]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.8...1.9.9
 [1.9.8]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.7...1.9.8
 [1.9.7]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.6...1.9.7

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
         "nnnick/chartjs": "^3.9",
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
-        "rhodeislandecms/ecms_profile": "0.9.31",
+        "rhodeislandecms/ecms_profile": "0.10.0",
         "state-of-rhode-island-ecms/ecms_patternlab": "0.7.3",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f9bcec8f5e7b755162d8fd5d16048f2d",
+    "content-hash": "6ad9217db66f5c471d4fef1becd6e44b",
     "packages": [
         {
             "name": "acquia/http-hmac-php",
@@ -13210,11 +13210,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "0.9.31",
+            "version": "0.10.0",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "d29cb54f0c9286a680eec68e05f2826d06412734"
+                "reference": "14375c9fd186e079668071505a9ebf1d61f6b049"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -13387,7 +13387,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2023-07-13T15:36:13+00:00"
+            "time": "2023-07-18T20:29:53+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",
@@ -19458,14 +19458,12 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "rhodeislandecms/ecms_profile": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
## [1.10.0] - 2023-07-13
### Changed
- RIGA-6: Upgrade to 1.10.0 to reflect drupal/core 9.4.x => 9.5.x upgrade.
- RIGA-6: Update rhodeislandecms/ecms_profile 0.9.31 => 0.10.0.