### PR TITLE
Fix permissions to view unpublished paragraphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIGA-377: Add drupal/paragraphs patch issue 3095959 comment 5.
 
 ### Changed
 
@@ -18,6 +19,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIGA-377: Fix permissions to view unpublished paragraphs (see patch).
 
 ### Security
 

--- a/composer.json
+++ b/composer.json
@@ -168,6 +168,9 @@
             },
             "drupal/feeds": {
                 "3158678 - FetcherResult::checkFile() throws \\RuntimeException, which is never caught": "https://www.drupal.org/files/issues/2022-09-27/feeds-3158678-9-catch-runtime-errors.patch"
+            },
+            "drupal/paragraphs": {
+                "3095959 - Paragraph type permissions conflicts with view unpublished paragraph permission": "https://www.drupal.org/files/issues/2019-11-22/paragraphs_type_permissions_view_unpublished_3095959-5.patch"
             }
         },
         "preserve-paths": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6ad9217db66f5c471d4fef1becd6e44b",
+    "content-hash": "5f6d231bd266e1829fd8e2dcb7552c9f",
     "packages": [
         {
             "name": "acquia/http-hmac-php",


### PR DESCRIPTION
<!-- INSTRUCTIONS
- Please use a meaningful pull request title which does not include the issue
  key or branch name.
- Please apply meaningful GitHub Labels to your pull request such as: PHP,
  Twig, SCSS, JS, etc.
- Please make sure you've reviewed the "Files changed" tab before opening this
  PR to ensure it includes what you expect (and nothing more) and adheres to
  our coding standards.
- Browser requirements can be found in docs/browser-requirements.md from the
  root of the project.
-->

## Summary
<!-- Include a summary of your changes that expands upon the title. -->
- Adds drupal/paragraphs patch issue 3095959 comment 5
- The "Paragraph type permissions" module creates a conflict when determining viewing permissions
  - See issue 3095959 "Paragraph type permissions conflicts with view unpublished paragraph permission"
  - https://www.drupal.org/project/paragraphs/issues/3095959

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIGA-377](https://thinkoomph.jira.com/browse/RIGA-377)
