### PR TITLE
Prepare CHANGELOG and dependencies for 1.10.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
-- RIGA-377: Add drupal/paragraphs patch issue 3095959 comment 5.
-- RIGA-405: Add drupal/core patch issue 3277784 comment 2.
 
 ### Changed
 
@@ -20,10 +18,20 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
-- RIGA-377: Fix permissions to view unpublished paragraphs (see patch).
-- RIGA-405: Fix missing sidebar nav menus (core patch).
 
 ### Security
+
+## [1.10.1] - 2023-07-27
+### Added
+- RIGA-377: Add drupal/paragraphs patch issue 3095959 comment 5.
+- RIGA-405: Add drupal/core patch issue 3277784 comment 2.
+
+### Changed
+- RIGA-6: Update rhodeislandecms/ecms_profile => 0.10.1.
+
+### Fixed
+- RIGA-377: Fix permissions to view unpublished paragraphs (see patch).
+- RIGA-405: Fix missing sidebar nav menus (core patch).
 
 ## [1.10.0] - 2023-07-13
 ### Changed
@@ -877,7 +885,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - Initial Release of the site.
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.0...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.1...HEAD
+[1.10.1]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.0...1.10.1
 [1.10.0]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.9...1.10.0
 [1.9.9]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.8...1.9.9
 [1.9.8]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.7...1.9.8

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
         "nnnick/chartjs": "^3.9",
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
-        "rhodeislandecms/ecms_profile": "0.10.0",
+        "rhodeislandecms/ecms_profile": "0.10.1",
         "state-of-rhode-island-ecms/ecms_patternlab": "0.7.3",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6ad9217db66f5c471d4fef1becd6e44b",
+    "content-hash": "e04fc22562977bd949cc8a9c43e775a9",
     "packages": [
         {
             "name": "acquia/http-hmac-php",
@@ -13210,11 +13210,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "0.10.0",
+            "version": "0.10.1",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "14375c9fd186e079668071505a9ebf1d61f6b049"
+                "reference": "5bc938214992b7b8b08e7c56a15c65d8078112d5"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -13387,7 +13387,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2023-07-18T20:29:53+00:00"
+            "time": "2023-07-27T08:24:01+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",


### PR DESCRIPTION
## [1.10.1] - 2023-07-27
### Added
- RIGA-377: Add drupal/paragraphs patch issue 3095959 comment 5.
- RIGA-405: Add drupal/core patch issue 3277784 comment 2.

### Changed
- RIGA-6: Update rhodeislandecms/ecms_profile => 0.10.1.

### Fixed
- RIGA-377: Fix permissions to view unpublished paragraphs (see patch).
- RIGA-405: Fix missing sidebar nav menus (core patch).