### PR TITLE
Set DB transaction isolation level to READ COMMITTED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIGA-406: Add settings.php rule to set DB isolation level to READ COMMITTED.
 
 ### Changed
 
@@ -18,6 +19,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIGA-406: Fix "Database Isolation Level" warning.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ## [Unreleased]
 ### Added
 - RIGA-406: Add settings.php rule to set DB isolation level to READ COMMITTED.
+- RIGA-406: Add drupal/core patch issue 1650930 comment 248.
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -156,8 +156,7 @@
             "drupal/core": {
                 "2259567 - Unnecessary restrictions on logo format: Can't upload replacement SVG logo": "patches/drupal-core-2259567-allow-svg.patch",
                 "3301239 - PoStreamReader::readLine() throws an error on module install": "https://www.drupal.org/files/issues/2023-01-17/drupal_core-PoStreamReader_readLine_throws_an_error_on_module_install-3301239-7.patch",
-                "3359511 - [regression] missing menu active trail in Drupal 9.5.9": "https://www.drupal.org/files/issues/2023-05-10/3359511-revert-3277784-2.patch",
-                "1650930 - Use READ COMMITTED by default for MySQL transactions": "https://www.drupal.org/files/issues/2023-04-25/1650930-248.patch"
+                "3359511 - [regression] missing menu active trail in Drupal 9.5.9": "https://www.drupal.org/files/issues/2023-05-10/3359511-revert-3277784-2.patch"
             },
             "drupal/media_revisions_ui": {
                 "3247661 - Add filename to output": "patches/3247661-media-revisions-filename.patch"

--- a/composer.json
+++ b/composer.json
@@ -156,7 +156,8 @@
             "drupal/core": {
                 "2259567 - Unnecessary restrictions on logo format: Can't upload replacement SVG logo": "patches/drupal-core-2259567-allow-svg.patch",
                 "3301239 - PoStreamReader::readLine() throws an error on module install": "https://www.drupal.org/files/issues/2023-01-17/drupal_core-PoStreamReader_readLine_throws_an_error_on_module_install-3301239-7.patch",
-                "3359511 - [regression] missing menu active trail in Drupal 9.5.9": "https://www.drupal.org/files/issues/2023-05-10/3359511-revert-3277784-2.patch"
+                "3359511 - [regression] missing menu active trail in Drupal 9.5.9": "https://www.drupal.org/files/issues/2023-05-10/3359511-revert-3277784-2.patch",
+                "1650930 - Use READ COMMITTED by default for MySQL transactions": "https://www.drupal.org/files/issues/2023-04-25/1650930-248.patch"
             },
             "drupal/media_revisions_ui": {
                 "3247661 - Add filename to output": "patches/3247661-media-revisions-filename.patch"

--- a/composer.json
+++ b/composer.json
@@ -173,6 +173,9 @@
             },
             "drupal/paragraphs": {
                 "3095959 - Paragraph type permissions conflicts with view unpublished paragraph permission": "https://www.drupal.org/files/issues/2019-11-22/paragraphs_type_permissions_view_unpublished_3095959-5.patch"
+            },
+            "drupal/honeypot": {
+                "2943526 - Missing primary key in table `honeypot_user`": "https://www.drupal.org/files/issues/2023-07-10/honeypot-add_primary_key-2943526-64.patch"
             }
         },
         "preserve-paths": [],

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -82,9 +82,9 @@ if (getenv('LANDO_INFO')) {
   }
 }
 
-$databases['default']['default']['init_commands'] = [
-  'isolation_level' => "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED",
-];
+//$databases['default']['default']['init_commands'] = [
+//  'isolation_level' => "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED",
+//];
 
 // Set DB transaction isolation level to 'READ COMMITTED' on Acquia environments.
 // Mysql/MariaDB default to 'REPEATABLE READ', but it can result in deadlocks.

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -85,17 +85,17 @@ if (getenv('LANDO_INFO')) {
 // Set DB transaction isolation level to 'READ COMMITTED' on Acquia environments.
 // Mysql/MariaDB default to 'REPEATABLE READ', but it can result in deadlocks.
 // See: https://www.drupal.org/docs/getting-started/system-requirements/setting-the-mysql-transaction-isolation-level.
-if (file_exists('/var/www/site-php')) {
-  global $conf, $databases;
-  $conf['acquia_hosting_settings_autoconnect'] = FALSE;
-  // EDIT next line to proper path to include file.
-
-  // @TO-DO: this will be a problem on site factory,
-  // Not sure how to address multisite.
-  require('/var/www/site-php/MYSITE/MYDATABASE-settings.inc');
-
-  $databases['default']['default']['init_commands'] = [
-    'isolation_level' => "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED",
-  ];
-  acquia_hosting_db_choose_active();
-}
+//if (file_exists('/var/www/site-php')) {
+//  global $conf, $databases;
+//  $conf['acquia_hosting_settings_autoconnect'] = FALSE;
+//  // EDIT next line to proper path to include file.
+//
+//  // @TO-DO: this will be a problem on site factory,
+//  // Not sure how to address multisite.
+//  require('/var/www/site-php/MYSITE/MYDATABASE-settings.inc');
+//
+//  $databases['default']['default']['init_commands'] = [
+//    'isolation_level' => "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED",
+//  ];
+//  acquia_hosting_db_choose_active();
+//}

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -78,3 +78,10 @@ if (getenv('LANDO_INFO')) {
     }
   }
 }
+
+// Set DB transaction isolation level to 'READ COMMITTED'.
+// Mysql/MariaDB default to 'REPEATABLE READ', but it can result in deadlocks.
+// See: https://www.drupal.org/docs/getting-started/system-requirements/setting-the-mysql-transaction-isolation-level.
+$databases['default']['default']['init_commands'] = [
+  'isolation_level' => 'SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED',
+];

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -81,25 +81,3 @@ if (getenv('LANDO_INFO')) {
     }
   }
 }
-
-//$databases['default']['default']['init_commands'] = [
-//  'isolation_level' => "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED",
-//];
-
-// Set DB transaction isolation level to 'READ COMMITTED' on Acquia environments.
-// Mysql/MariaDB default to 'REPEATABLE READ', but it can result in deadlocks.
-// See: https://www.drupal.org/docs/getting-started/system-requirements/setting-the-mysql-transaction-isolation-level.
-//if (file_exists('/var/www/site-php')) {
-//  global $conf, $databases;
-//  $conf['acquia_hosting_settings_autoconnect'] = FALSE;
-//  // EDIT next line to proper path to include file.
-//
-//  // @TO-DO: this will be a problem on site factory,
-//  // Not sure how to address multisite.
-//  require('/var/www/site-php/MYSITE/MYDATABASE-settings.inc');
-//
-//  $databases['default']['default']['init_commands'] = [
-//    'isolation_level' => "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED",
-//  ];
-//  acquia_hosting_db_choose_active();
-//}

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -82,6 +82,10 @@ if (getenv('LANDO_INFO')) {
   }
 }
 
+$databases['default']['default']['init_commands'] = [
+  'isolation_level' => "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED",
+];
+
 // Set DB transaction isolation level to 'READ COMMITTED' on Acquia environments.
 // Mysql/MariaDB default to 'REPEATABLE READ', but it can result in deadlocks.
 // See: https://www.drupal.org/docs/getting-started/system-requirements/setting-the-mysql-transaction-isolation-level.

--- a/factory-hooks/post-settings-php/set-db-isolation-level.php
+++ b/factory-hooks/post-settings-php/set-db-isolation-level.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @file
+ * Example implementation of ACSF post-settings-php hook.
+ *
+ * @see https://docs.acquia.com/site-factory/extend/hooks
+ */
+
+// Changing the database transaction isolation level from `REPEATABLE-READ`
+// to `READ-COMMITTED` to avoid/minimize the deadlocks.
+// @see https://support-acquia.force.com/s/article/360005253954-Fixing-database-deadlocks
+// for reference.
+
+$databases['default']['default']['init_commands'] = [
+  'isolation_level' => "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED",
+];
+if (file_exists('/var/www/site-php') && function_exists("acquia_hosting_db_choose_active")) {
+  acquia_hosting_db_choose_active($conf['acquia_hosting_site_info']['db'], 'default', $databases, $conf);
+}
+
+
+
+//// Set DB transaction isolation level to 'READ COMMITTED' on Acquia environments.
+//// Mysql/MariaDB default to the 'REPEATABLE READ' setting, but it can result in deadlocks.
+//// See: https://www.drupal.org/docs/getting-started/system-requirements/setting-the-mysql-transaction-isolation-level.
+//if (file_exists('/var/www/site-php')) {
+//  global $conf, $databases;
+//  $conf['acquia_hosting_settings_autoconnect'] = FALSE;
+//
+//  // Get drupal version and site settings from active environment.
+//  // These are needed to generate file path to the 'settings.inc' file.
+//  // Approach borrowed from 'modules/contrib/acsf/acsf_init/lib/sites/g/settings.php'.
+//  $drupal_version = 8;
+//  if (version_compare(\Drupal::VERSION, '9', '>=') && version_compare(\Drupal::VERSION, '10', '<')) {
+//    $drupal_version = 9;
+//  }
+//  elseif (version_compare(\Drupal::VERSION, '10', '>=')) {
+//    $drupal_version = 10;
+//  }
+//  $site_settings = !empty($GLOBALS['gardens_site_settings'])
+//    ? $GLOBALS['gardens_site_settings']
+//    : ['site' => '', 'env' => '', 'conf' => ['acsf_db_name' => '']];
+//
+//  // Generate file path, and require settings file.
+//  $_acsf_include_file = "/var/www/site-php/{$site_settings['site']}.{$site_settings['env']}/D{$drupal_version}-{$site_settings['env']}-{$site_settings['conf']['acsf_db_name']}-settings.inc";
+//  require $_acsf_include_file;
+//
+//  $databases['default']['default']['init_commands'] = [
+//    'isolation_level' => "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED",
+//  ];
+//  if (function_exists("acquia_hosting_db_choose_active")) {
+//    acquia_hosting_db_choose_active();
+//  }
+//}

--- a/factory-hooks/post-settings-php/set-db-isolation-level.php
+++ b/factory-hooks/post-settings-php/set-db-isolation-level.php
@@ -18,38 +18,3 @@ $databases['default']['default']['init_commands'] = [
 if (file_exists('/var/www/site-php') && function_exists("acquia_hosting_db_choose_active")) {
   acquia_hosting_db_choose_active($conf['acquia_hosting_site_info']['db'], 'default', $databases, $conf);
 }
-
-
-
-//// Set DB transaction isolation level to 'READ COMMITTED' on Acquia environments.
-//// Mysql/MariaDB default to the 'REPEATABLE READ' setting, but it can result in deadlocks.
-//// See: https://www.drupal.org/docs/getting-started/system-requirements/setting-the-mysql-transaction-isolation-level.
-//if (file_exists('/var/www/site-php')) {
-//  global $conf, $databases;
-//  $conf['acquia_hosting_settings_autoconnect'] = FALSE;
-//
-//  // Get drupal version and site settings from active environment.
-//  // These are needed to generate file path to the 'settings.inc' file.
-//  // Approach borrowed from 'modules/contrib/acsf/acsf_init/lib/sites/g/settings.php'.
-//  $drupal_version = 8;
-//  if (version_compare(\Drupal::VERSION, '9', '>=') && version_compare(\Drupal::VERSION, '10', '<')) {
-//    $drupal_version = 9;
-//  }
-//  elseif (version_compare(\Drupal::VERSION, '10', '>=')) {
-//    $drupal_version = 10;
-//  }
-//  $site_settings = !empty($GLOBALS['gardens_site_settings'])
-//    ? $GLOBALS['gardens_site_settings']
-//    : ['site' => '', 'env' => '', 'conf' => ['acsf_db_name' => '']];
-//
-//  // Generate file path, and require settings file.
-//  $_acsf_include_file = "/var/www/site-php/{$site_settings['site']}.{$site_settings['env']}/D{$drupal_version}-{$site_settings['env']}-{$site_settings['conf']['acsf_db_name']}-settings.inc";
-//  require $_acsf_include_file;
-//
-//  $databases['default']['default']['init_commands'] = [
-//    'isolation_level' => "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED",
-//  ];
-//  if (function_exists("acquia_hosting_db_choose_active")) {
-//    acquia_hosting_db_choose_active();
-//  }
-//}

--- a/factory-hooks/post-settings-php/z_database_settings.php
+++ b/factory-hooks/post-settings-php/z_database_settings.php
@@ -23,7 +23,43 @@ if (isset($_ENV['AH_SITE_ENVIRONMENT'])) {
 //    ],
   );
 
-  $databases['default']['default']['init_commands'] = [
-    'isolation_level' => 'SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED',
-  ];
+//  $databases['default']['default']['init_commands'] = [
+//    'isolation_level' => 'SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED',
+//  ];
+
+//  // Set DB transaction isolation level to 'READ COMMITTED' on Acquia environments.
+//  // Mysql/MariaDB default to the 'REPEATABLE READ' setting, but it can result in deadlocks.
+//  // See: https://www.drupal.org/docs/getting-started/system-requirements/setting-the-mysql-transaction-isolation-level.
+//  if (file_exists('/var/www/site-php')) {
+//    global $conf, $databases;
+//    $conf['acquia_hosting_settings_autoconnect'] = FALSE;
+//
+//    // Get drupal version and site settings from active environment.
+//    // These are needed to generate file path to the 'settings.inc' file.
+//    // Approach borrowed from 'modules/contrib/acsf/acsf_init/lib/sites/g/settings.php'.
+//    $drupal_version = 8;
+//    if (version_compare(\Drupal::VERSION, '9', '>=') && version_compare(\Drupal::VERSION, '10', '<')) {
+//      $drupal_version = 9;
+//    }
+//    elseif (version_compare(\Drupal::VERSION, '10', '>=')) {
+//      $drupal_version = 10;
+//    }
+//    $site_settings = !empty($GLOBALS['gardens_site_settings'])
+//      ? $GLOBALS['gardens_site_settings']
+//      : ['site' => '', 'env' => '', 'conf' => ['acsf_db_name' => '']];
+//
+//    // Generate file path, and require settings file.
+//    $_acsf_include_file = "/var/www/site-php/{$site_settings['site']}.{$site_settings['env']}/D{$drupal_version}-{$site_settings['env']}-{$site_settings['conf']['acsf_db_name']}-settings.inc";
+//    require $_acsf_include_file;
+//
+//    $databases['default']['default']['init_commands'] = [
+//      'isolation_level' => "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED",
+//    ];
+//    if (function_exists("acquia_hosting_db_choose_active")) {
+//      acquia_hosting_db_choose_active();
+//    }
+//  }
+
 }
+
+

--- a/factory-hooks/post-settings-php/z_database_settings.php
+++ b/factory-hooks/post-settings-php/z_database_settings.php
@@ -18,8 +18,8 @@ if (isset($_ENV['AH_SITE_ENVIRONMENT'])) {
     'port' => '3306',
     'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
     'driver' => 'mysql',
-    'init_commands' => [
-      'isolation_level' => 'SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED',
-    ],
+//    'init_commands' => [
+//      'isolation_level' => 'SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED',
+//    ],
   );
 }

--- a/factory-hooks/post-settings-php/z_database_settings.php
+++ b/factory-hooks/post-settings-php/z_database_settings.php
@@ -22,4 +22,8 @@ if (isset($_ENV['AH_SITE_ENVIRONMENT'])) {
 //      'isolation_level' => 'SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED',
 //    ],
   );
+
+  $databases['default']['default']['init_commands'] = [
+    'isolation_level' => 'SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED',
+  ];
 }

--- a/factory-hooks/post-settings-php/z_database_settings.php
+++ b/factory-hooks/post-settings-php/z_database_settings.php
@@ -18,48 +18,5 @@ if (isset($_ENV['AH_SITE_ENVIRONMENT'])) {
     'port' => '3306',
     'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
     'driver' => 'mysql',
-//    'init_commands' => [
-//      'isolation_level' => 'SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED',
-//    ],
   );
-
-//  $databases['default']['default']['init_commands'] = [
-//    'isolation_level' => 'SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED',
-//  ];
-
-//  // Set DB transaction isolation level to 'READ COMMITTED' on Acquia environments.
-//  // Mysql/MariaDB default to the 'REPEATABLE READ' setting, but it can result in deadlocks.
-//  // See: https://www.drupal.org/docs/getting-started/system-requirements/setting-the-mysql-transaction-isolation-level.
-//  if (file_exists('/var/www/site-php')) {
-//    global $conf, $databases;
-//    $conf['acquia_hosting_settings_autoconnect'] = FALSE;
-//
-//    // Get drupal version and site settings from active environment.
-//    // These are needed to generate file path to the 'settings.inc' file.
-//    // Approach borrowed from 'modules/contrib/acsf/acsf_init/lib/sites/g/settings.php'.
-//    $drupal_version = 8;
-//    if (version_compare(\Drupal::VERSION, '9', '>=') && version_compare(\Drupal::VERSION, '10', '<')) {
-//      $drupal_version = 9;
-//    }
-//    elseif (version_compare(\Drupal::VERSION, '10', '>=')) {
-//      $drupal_version = 10;
-//    }
-//    $site_settings = !empty($GLOBALS['gardens_site_settings'])
-//      ? $GLOBALS['gardens_site_settings']
-//      : ['site' => '', 'env' => '', 'conf' => ['acsf_db_name' => '']];
-//
-//    // Generate file path, and require settings file.
-//    $_acsf_include_file = "/var/www/site-php/{$site_settings['site']}.{$site_settings['env']}/D{$drupal_version}-{$site_settings['env']}-{$site_settings['conf']['acsf_db_name']}-settings.inc";
-//    require $_acsf_include_file;
-//
-//    $databases['default']['default']['init_commands'] = [
-//      'isolation_level' => "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED",
-//    ];
-//    if (function_exists("acquia_hosting_db_choose_active")) {
-//      acquia_hosting_db_choose_active();
-//    }
-//  }
-
 }
-
-

--- a/factory-hooks/post-settings-php/z_database_settings.php
+++ b/factory-hooks/post-settings-php/z_database_settings.php
@@ -18,5 +18,8 @@ if (isset($_ENV['AH_SITE_ENVIRONMENT'])) {
     'port' => '3306',
     'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
     'driver' => 'mysql',
+    'init_commands' => [
+      'isolation_level' => 'SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED',
+    ],
   );
 }

--- a/factory-hooks/pre-settings-php/prepare-db-isolation-setting.php
+++ b/factory-hooks/pre-settings-php/prepare-db-isolation-setting.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * @file
+ * Prepare environment to update DB transaction isolation level.
+ *
+ * @see https://docs.acquia.com/site-factory/extend/hooks/settings-php/#avoiding-database-deadlocks
+ */
+
+// Prevent auto-connecting to DB, so we can alter settings first.
+$conf['acquia_hosting_settings_autoconnect'] = FALSE;


### PR DESCRIPTION
<!-- INSTRUCTIONS
- Please use a meaningful pull request title which does not include the issue
  key or branch name.
- Please apply meaningful GitHub Labels to your pull request such as: PHP,
  Twig, SCSS, JS, etc.
- Please make sure you've reviewed the "Files changed" tab before opening this
  PR to ensure it includes what you expect (and nothing more) and adheres to
  our coding standards.
- Browser requirements can be found in docs/browser-requirements.md from the
  root of the project.
-->

## Summary
<!-- Include a summary of your changes that expands upon the title. -->
New warning appeared since Drupal core 9.4 => 9.5 upgrade:

_"Database Isolation Level: REPEATABLE-READ
For the best performance and to minimize locking issues, the READ-COMMITTED transaction isolation level is recommended. See the [setting MySQL transaction isolation level](https://www.drupal.org/docs/system-requirements/setting-the-mysql-transaction-isolation-level) page for more information."_

This PR adds new rule to settings.php file to update this config setting
## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | yes
| Risk level | Medium
| Relevant links | [RIGA-406](https://thinkoomph.jira.com/browse/RIGA-406)
