### PR TITLE
Prepare CHANGELOG and dependencies for 1.10.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,6 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
-- RIGA-406: Update drupal/admin_toolbar 3.4.0 => 3.4.1
-- RIGA-406: Update drupal/easy_breadcrumb ^2.0 => 2.0.5
-- RIGA-406: Update drupal/metatag ^1.14 => ^1.26
-- RIGA-406: Update drupal/token ^1.7 => ^1.12
 
 ### Deprecated
 
@@ -24,6 +20,14 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Fixed
 
 ### Security
+
+## [1.10.2] 2023-08-10
+### Changed
+- RIGA-6: Update rhodeislandecms/ecms_profile => 0.10.2.
+- RIGA-406: Update drupal/admin_toolbar 3.4.0 => 3.4.1.
+- RIGA-406: Update drupal/easy_breadcrumb ^2.0 => 2.0.5.
+- RIGA-406: Update drupal/metatag ^1.14 => ^1.26.
+- RIGA-406: Update drupal/token ^1.7 => ^1.12.
 
 ## [1.10.1] - 2023-07-27
 ### Added
@@ -889,7 +893,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - Initial Release of the site.
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.1...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.2...HEAD
+[1.10.2]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.1...1.10.2
 [1.10.1]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.0...1.10.1
 [1.10.0]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.9...1.10.0
 [1.9.9]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.8...1.9.9

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
         "nnnick/chartjs": "^3.9",
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
-        "rhodeislandecms/ecms_profile": "dev-RIGA-406/august-module-updates",
+        "rhodeislandecms/ecms_profile": "0.10.2",
         "state-of-rhode-island-ecms/ecms_patternlab": "0.7.3",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "777f22becfd627f2775c9503f8c1888f",
+    "content-hash": "3331f7396426aabdfbe94bc0e001fc3d",
     "packages": [
         {
             "name": "acquia/http-hmac-php",
@@ -13214,11 +13214,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "dev-RIGA-406/august-module-updates",
+            "version": "0.10.2",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "42257f01a7e1f406360a44af426f224680ca3630"
+                "reference": "7d4fc2b41c7fdcd01c72f04eb23c78c293078b17"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -13391,7 +13391,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2023-08-07T17:17:27+00:00"
+            "time": "2023-08-10T06:50:29+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",
@@ -19462,9 +19462,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "rhodeislandecms/ecms_profile": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
## [1.10.2] 2023-08-10
### Changed
- RIGA-6: Update rhodeislandecms/ecms_profile => 0.10.2.
- RIGA-406: Update drupal/admin_toolbar 3.4.0 => 3.4.1.
- RIGA-406: Update drupal/easy_breadcrumb ^2.0 => 2.0.5.
- RIGA-406: Update drupal/metatag ^1.14 => ^1.26.
- RIGA-406: Update drupal/token ^1.7 => ^1.12.