### PR TITLE
Prepare CHANGELOG and dependencies for 1.10.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,6 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
-- RIGA-409: Update drupal/acquia_search 3.1.7 => 3.1.10.
-- RIGA-409: Update drupal/acquia_connector 4.0.1 => 4.0.5.
-- RIGA-409: Update drupal/acsf 2.73.0 => 2.75.0.
 
 ### Deprecated
 
@@ -24,7 +21,13 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ### Security
 
-## [1.10.2] 2023-08-10
+## [1.10.3] - 2023-08-31
+### Changed
+- RIGA-409: Update drupal/acquia_search 3.1.7 => 3.1.10.
+- RIGA-409: Update drupal/acquia_connector 4.0.1 => 4.0.5.
+- RIGA-409: Update drupal/acsf 2.73.0 => 2.75.0.
+
+## [1.10.2] - 2023-08-10
 ### Changed
 - RIGA-6: Update rhodeislandecms/ecms_profile => 0.10.2.
 - RIGA-406: Update drupal/admin_toolbar 3.4.0 => 3.4.1.
@@ -896,7 +899,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - Initial Release of the site.
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.2...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.3...HEAD
+[1.10.3]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.2...1.10.3
 [1.10.2]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.1...1.10.2
 [1.10.1]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.0...1.10.1
 [1.10.0]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.9.9...1.10.0

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
         "nnnick/chartjs": "^3.9",
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
-        "rhodeislandecms/ecms_profile": "dev-RIGA-409/august-module-updates-pt2-2",
+        "rhodeislandecms/ecms_profile": "0.10.3",
         "state-of-rhode-island-ecms/ecms_patternlab": "0.7.3",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bb29c39610cf6b1a8654dacf3394ab97",
+    "content-hash": "b68a06e7167e97cff3adde80ff84859a",
     "packages": [
         {
             "name": "acquia/http-hmac-php",
@@ -13212,11 +13212,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "dev-RIGA-409/august-module-updates-pt2-2",
+            "version": "0.10.3",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "24b8c5eccea36ab172da7e08df0b082e755bd422"
+                "reference": "e46ace2fd916bb127f58f105d584e86e2b74a065"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -13389,7 +13389,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2023-08-24T13:35:42+00:00"
+            "time": "2023-08-29T21:19:38+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",
@@ -19460,9 +19460,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "rhodeislandecms/ecms_profile": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
## [1.10.3] - 2023-08-31
### Changed
- RIGA-409: Update drupal/acquia_search 3.1.7 => 3.1.10.
- RIGA-409: Update drupal/acquia_connector 4.0.1 => 4.0.5.
- RIGA-409: Update drupal/acsf 2.73.0 => 2.75.0.