### PR TITLE
Prepare CHANGELOG and dependencies for 1.10.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,6 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
-- RIGA-414: Update php 8.0 => 8.1 in lando and composer.
-- RIGA-414: Upgrade drush/drush 10.3.6 => 10.6.2.
-- RIGA-414: Upgrade drush8 => drush10 in Acquia hooks.
-- RIGA-414: Update lando version 3.4.0 => 3.18.0 in oomph actions.
 
 ### Deprecated
 
@@ -24,6 +20,13 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Fixed
 
 ### Security
+
+## [1.10.5] - 2023-09-28
+### Changed
+- RIGA-414: Update php 8.0 => 8.1 in lando and composer.
+- RIGA-414: Upgrade drush/drush 10.3.6 => 10.6.2.
+- RIGA-414: Upgrade drush8 => drush10 in Acquia hooks.
+- RIGA-414: Update lando version 3.4.0 => 3.18.0 in oomph actions.
 
 ## [1.10.4] - 2023-09-21
 ### Changed
@@ -910,7 +913,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - Initial Release of the site.
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.4...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.5...HEAD
+[1.10.5]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.4...1.10.5
 [1.10.4]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.3...1.10.4
 [1.10.3]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.2...1.10.3
 [1.10.2]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.1...1.10.2

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
         "nnnick/chartjs": "^3.9",
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
-        "rhodeislandecms/ecms_profile": "dev-RIGA-414/php-8.1-upgrade",
+        "rhodeislandecms/ecms_profile": "0.10.4",
         "state-of-rhode-island-ecms/ecms_patternlab": "0.7.3",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3ca70af7e2cc0472fdeff69e59ec512b",
+    "content-hash": "c2f612ff1c5c6153d45a72970d274391",
     "packages": [
         {
             "name": "acquia/http-hmac-php",
@@ -13162,11 +13162,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "dev-RIGA-414/php-8.1-upgrade",
+            "version": "0.10.4",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "45296b9fff88c9c3b4ae5c9d9498e4ce7f97c6eb"
+                "reference": "3ed62ced3ff0197c6a65644a0bbbebc0b363ecad"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -13339,7 +13339,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2023-09-21T00:16:52+00:00"
+            "time": "2023-09-28T08:12:36+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",
@@ -19412,9 +19412,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "rhodeislandecms/ecms_profile": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
## [1.10.5] - 2023-09-28
### Changed
- RIGA-414: Update php 8.0 => 8.1 in lando and composer.
- RIGA-414: Upgrade drush/drush 10.3.6 => 10.6.2.
- RIGA-414: Upgrade drush8 => drush10 in Acquia hooks.
- RIGA-414: Update lando version 3.4.0 => 3.18.0 in oomph actions.