### PR TITLE
Prepare CHANGELOG and dependencies for 1.10.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [1.10.6] - 2023-10-19
+### Added
 - RIGA-322: Install drupal/upgrade_status 4.0.0.
 - RIGA-401: Install drupal/crop 2.3.0.
 - RIGA-401: Install drupal/entity_usage 2.0.0-beta12.
@@ -24,6 +37,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIGA-322: Add drupal/migrate_process_trim patch issue 3288638 comment 2.
 
 ### Changed
+- RIGA-6: Update rhodeislandecms/ecms_profile => 0.10.5.
+- RIGA-6: Update state-of-rhode-island-ecms/ecms_patternlab => 0.7.4.
 - RIGA-322: Upgrade drupal/better_exposed_filters 5.0.0 => 6.0.2.
 - RIGA-322: Upgrade drupal/captcha 1.10.0 => 2.0.5.
 - RIGA-322: Upgrade drupal/components 2.4.0 => 3.0.0-beta3.
@@ -62,14 +77,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIGA-322: Upgrade drupal/webform_encrypt dev-1.x => 2.0.0-alpha1.
 - RIGA-322: Upgrade drupal/views_database_connector 1.4.0 => 2.0.1.
 
-### Deprecated
-
 ### Removed
 - RIGA-322: Remove module drupal/views_ajax_get.
-
-### Fixed
-
-### Security
 
 ## [1.10.5] - 2023-09-28
 ### Changed
@@ -963,7 +972,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - Initial Release of the site.
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.5...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.6...HEAD
+[1.10.6]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.5...1.10.6
 [1.10.5]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.4...1.10.5
 [1.10.4]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.3...1.10.4
 [1.10.3]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.2...1.10.3

--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
         "nnnick/chartjs": "^3.9",
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
-        "rhodeislandecms/ecms_profile": "dev-RIGA-415/install-new-modules-p2",
+        "rhodeislandecms/ecms_profile": "0.10.5",
         "state-of-rhode-island-ecms/ecms_patternlab": "0.7.4",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "732c9c427b2138495b3ea49551fb2a47",
+    "content-hash": "edd7ce1a98cfdfea9be3f0714d13c19a",
     "packages": [
         {
             "name": "acquia/http-hmac-php",
@@ -14134,11 +14134,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "dev-RIGA-415/install-new-modules-p2",
+            "version": "0.10.5",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "7a8746bd491fdaa125d273084e92d2d0d7f5a692"
+                "reference": "d2dbf320b41f60c291878bc1afe608c447b82bad"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -14317,7 +14317,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2023-10-19T03:27:46+00:00"
+            "time": "2023-10-19T04:31:18+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",
@@ -22042,8 +22042,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "drupal/config_update": 15,
-        "drupal/feeds": 10,
-        "rhodeislandecms/ecms_profile": 20
+        "drupal/feeds": 10
     },
     "prefer-stable": true,
     "prefer-lowest": false,


### PR DESCRIPTION
## [1.10.6] - 2023-10-19
### Added
- RIGA-322: Install drupal/upgrade_status 4.0.0.
- RIGA-401: Install drupal/crop 2.3.0.
- RIGA-401: Install drupal/entity_usage 2.0.0-beta12.
- RIGA-401: Install drupal/focal_point 2.0.2.
- RIGA-401: Install drupal/iek 1.3.0.
- RIGA-415: Install drupal/advagg 6.0.0-alpha1.
- RIGA-415: Install drupal/conditional_fields 4.0.0-alpha5.
- RIGA-415: Install drupal/field_group 3.4.0.
- RIGA-415: Install drupal/quick_node_clone 1.16.0.
- RIGA-322: Add drupal/ckeditor_entity_link patch issue 3296754 comment 3.
- RIGA-322: Add drupal/easy_breadcrumb patch issue 3284123 comment 13.
- RIGA-322: Add drupal/migrate_process_trim patch issue 3288638 comment 2.

### Changed
- RIGA-6: Update rhodeislandecms/ecms_profile => 0.10.5.
- RIGA-6: Update state-of-rhode-island-ecms/ecms_patternlab => 0.7.4.
- RIGA-322: Upgrade drupal/better_exposed_filters 5.0.0 => 6.0.2.
- RIGA-322: Upgrade drupal/captcha 1.10.0 => 2.0.5.
- RIGA-322: Upgrade drupal/components 2.4.0 => 3.0.0-beta3.
- RIGA-322: Upgrade drupal/config_update 1.7.0 => 2.0.0-alpha3.
- RIGA-322: Upgrade drupal/content_moderation_notifications dev-3.x => 3.5.0.
- RIGA-322: Upgrade drupal/ctools 3.11.0 => 3.14.0.
- RIGA-322: Upgrade drupal/devel 4.0.1 => 5.1.2.
- RIGA-322: Upgrade drupal/features 3.12.0 => 3.13.0.
- RIGA-322: Upgrade drupal/feeds 3.0.0-beta2 => 3.0.0-beta4.
- RIGA-322: Upgrade drupal/google_tag 1.4.0 => 2.0.2.
- RIGA-322: Upgrade drupal/google_translator 1.0.0 => 2.1.0.
- RIGA-322: Upgrade drupal/http_cache_control 2.0.0 => 2.1.0.
- RIGA-322: Upgrade drupal/jquery_ui_datepicker 1.4.0 => 2.0.0.
- RIGA-322: Upgrade drupal/jquery_ui_draggable 1.2.0 => 2.0.0.
- RIGA-322: Upgrade drupal/jquery_ui_droppable 1.2.0 => 1.5.0.
- RIGA-322: Upgrade drupal/jquery_ui_slider 1.1.0 => 2.0.0.
- RIGA-322: Upgrade drupal/language_cookie dev-1.x => 2.0.1.
- RIGA-322: Upgrade drupal/language_neutral_aliases 3.0.0 => 3.1.0.
- RIGA-322: Upgrade drupal/layout_builder_modal 1.1.0 => 1.2.0.
- RIGA-322: Upgrade drupal/media_library_theme_reset 1.1.0 => 1.5.0.
- RIGA-322: Upgrade drupal/menu_block dev-1.x => 1.10.0.
- RIGA-322: Upgrade drupal/menu_force 1.2.0 => 2.0.0.
- RIGA-322: Upgrade drupal/migrate_plus 5.3.0 => 6.0.1.
- RIGA-322: Upgrade drupal/migrate_tools 5.1.0 => 6.0.2.
- RIGA-322: Upgrade drupal/page_manager 4.0.0-beta6 => 4.0.0-rc2.
- RIGA-322: Upgrade drupal/panels 4.6.0 => 4.7.0.
- RIGA-322: Upgrade drupal/paragraphs 1.15.0 => 1.16.0.
- RIGA-322: Upgrade drupal/publishcontent 1.5.0 => 1.6.0.
- RIGA-322: Upgrade drupal/rabbit_hole 1.0.0-beta10 => 1.0.0-beta11.
- RIGA-322: Upgrade drupal/search_api_exclude 2.0.0 => 2.0.2.
- RIGA-322: Upgrade drupal/simple_menu_permissions 1.4.0 => 2.0.0.
- RIGA-322: Upgrade drupal/svg_image 1.16.0 => 3.0.1.
- RIGA-322: Upgrade drupal/twig_tweak 2.10.0 => 3.2.1.
- RIGA-322: Upgrade drupal/twig_vardumper 3.0.2 => 3.1.0.
- RIGA-322: Upgrade drupal/webform 6.1.4 => 6.2.0-beta6.
- RIGA-322: Upgrade drupal/webform_encrypt dev-1.x => 2.0.0-alpha1.
- RIGA-322: Upgrade drupal/views_database_connector 1.4.0 => 2.0.1.

### Removed
- RIGA-322: Remove module drupal/views_ajax_get.