### PR TITLE
Remove unneeded access check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
         "nnnick/chartjs": "^3.9",
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
-        "rhodeislandecms/ecms_profile": "0.10.5",
+        "rhodeislandecms/ecms_profile": "dev-RIGA-426/fix-search-access-check",
         "state-of-rhode-island-ecms/ecms_patternlab": "0.7.4",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "edd7ce1a98cfdfea9be3f0714d13c19a",
+    "content-hash": "0417f606f47415db157b3ac7c4651263",
     "packages": [
         {
             "name": "acquia/http-hmac-php",
@@ -14134,11 +14134,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "0.10.5",
+            "version": "dev-RIGA-426/fix-search-access-check",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "d2dbf320b41f60c291878bc1afe608c447b82bad"
+                "reference": "9d805dd460676e3141512f103201312a91d96964"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -14317,7 +14317,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2023-10-19T04:31:18+00:00"
+            "time": "2023-10-19T15:56:22+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",
@@ -22042,7 +22042,8 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "drupal/config_update": 15,
-        "drupal/feeds": 10
+        "drupal/feeds": 10,
+        "rhodeislandecms/ecms_profile": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,


### PR DESCRIPTION
<!-- INSTRUCTIONS
- Please use a meaningful pull request title which does not include the issue
  key or branch name.
- Please apply meaningful GitHub Labels to your pull request such as: PHP,
  Twig, SCSS, JS, etc.
- Please make sure you've reviewed the "Files changed" tab before opening this
  PR to ensure it includes what you expect (and nothing more) and adheres to
  our coding standards.
- Browser requirements can be found in docs/browser-requirements.md from the
  root of the project.
-->

## Summary
<!-- Include a summary of your changes that expands upon the title. -->
- D10 now requires `accessCheck()` functions on all entity queries.
- An access check had been accidentally placed on a Response query instead, which is not an available method
  - This removes the unneeded access check.

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIGA-426](https://thinkoomph.jira.com/browse/RIGA-426)