### PR TITLE
Prepare CHANGELOG and dependencies for 1.10.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ### Security
 
+## [1.10.7] - 2023-10-19
+### Changed
+- RIGA-6: Update rhodeislandecms/ecms_profile => 0.10.6.
+
 ## [1.10.6] - 2023-10-19
 ### Added
 - RIGA-322: Install drupal/upgrade_status 4.0.0.
@@ -972,7 +976,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - Initial Release of the site.
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.6...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.7...HEAD
+[1.10.7]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.6...1.10.7
 [1.10.6]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.5...1.10.6
 [1.10.5]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.4...1.10.5
 [1.10.4]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/1.10.3...1.10.4

--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
         "nnnick/chartjs": "^3.9",
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
-        "rhodeislandecms/ecms_profile": "0.10.5",
+        "rhodeislandecms/ecms_profile": "0.10.6",
         "state-of-rhode-island-ecms/ecms_patternlab": "0.7.4",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "edd7ce1a98cfdfea9be3f0714d13c19a",
+    "content-hash": "29decf7258b89d537342a12886e16a55",
     "packages": [
         {
             "name": "acquia/http-hmac-php",
@@ -14134,11 +14134,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "0.10.5",
+            "version": "0.10.6",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "d2dbf320b41f60c291878bc1afe608c447b82bad"
+                "reference": "064e874cda0305a8c037cd9f51e1f393a3dc723f"
             },
             "require": {
                 "composer/installers": "^1.9",
@@ -14317,7 +14317,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2023-10-19T04:31:18+00:00"
+            "time": "2023-10-19T17:52:41+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",


### PR DESCRIPTION
## [1.10.7] - 2023-10-19
### Changed
- RIGA-6: Update rhodeislandecms/ecms_profile => 0.10.6.