### PR TITLE
Riga 408/fix db isolation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIGA-408: Add hooks to set DB isolation level REPEATABLE READ => READ COMMITTED.
+- RIGA-408: Add drupal/core patch issue 1650930 comment 248.
+- RIGA-408: Add drupal/honeypot patch issue 2943526 comment 64.
 
 ### Changed
 
@@ -18,6 +21,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIGA-408: Fix "Database Isolation Level" warning.
 
 ### Security
 

--- a/composer.json
+++ b/composer.json
@@ -156,7 +156,8 @@
             "drupal/core": {
                 "2259567 - Unnecessary restrictions on logo format: Can't upload replacement SVG logo": "patches/drupal-core-2259567-allow-svg.patch",
                 "3301239 - PoStreamReader::readLine() throws an error on module install": "https://www.drupal.org/files/issues/2023-01-17/drupal_core-PoStreamReader_readLine_throws_an_error_on_module_install-3301239-7.patch",
-                "3359511 - [regression] missing menu active trail in Drupal 9.5.9": "https://www.drupal.org/files/issues/2023-05-10/3359511-revert-3277784-2.patch"
+                "3359511 - [regression] missing menu active trail in Drupal 9.5.9": "https://www.drupal.org/files/issues/2023-05-10/3359511-revert-3277784-2.patch",
+                "1650930 - Use READ COMMITTED by default for MySQL transactions": "https://www.drupal.org/files/issues/2023-04-25/1650930-248.patch"
             },
             "drupal/media_revisions_ui": {
                 "3247661 - Add filename to output": "patches/3247661-media-revisions-filename.patch"
@@ -172,6 +173,9 @@
             },
             "drupal/paragraphs": {
                 "3095959 - Paragraph type permissions conflicts with view unpublished paragraph permission": "https://www.drupal.org/files/issues/2019-11-22/paragraphs_type_permissions_view_unpublished_3095959-5.patch"
+            },
+            "drupal/honeypot": {
+                "2943526 - Missing primary key in table `honeypot_user`": "https://www.drupal.org/files/issues/2023-07-10/honeypot-add_primary_key-2943526-64.patch"
             }
         },
         "preserve-paths": [],

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -62,6 +62,9 @@ if (getenv('LANDO_INFO')) {
     'port' => $lando_info['database']['internal_connection']['port'],
     'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
     'driver' => 'mysql',
+    'init_commands' => [
+      'isolation_level' => 'SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED',
+    ],
   ];
 
   // Check for PHP Memcached libraries.

--- a/factory-hooks/post-settings-php/set-db-isolation-level.php
+++ b/factory-hooks/post-settings-php/set-db-isolation-level.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @file
+ * Set the database transaction isolation level to `READ-COMMITTED`.
+ *
+ * @see https://support-acquia.force.com/s/article/360005253954-Fixing-database-deadlocks
+ * @see https://www.drupal.org/docs/getting-started/system-requirements/setting-the-mysql-transaction-isolation-level
+ */
+
+// Set DB transaction isolation level to 'READ COMMITTED' on Acquia environments.
+// Mysql and MariaDB use default setting 'REPEATABLE READ', but it can result in deadlocks.
+$databases['default']['default']['init_commands'] = [
+  'isolation_level' => "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED",
+];
+if (file_exists('/var/www/site-php') && function_exists("acquia_hosting_db_choose_active")) {
+  acquia_hosting_db_choose_active($conf['acquia_hosting_site_info']['db'], 'default', $databases, $conf);
+}

--- a/factory-hooks/pre-settings-php/prepare-db-isolation-level.php
+++ b/factory-hooks/pre-settings-php/prepare-db-isolation-level.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * @file
+ * Prepare environment to update DB transaction isolation level.
+ *
+ * @see https://docs.acquia.com/site-factory/extend/hooks/settings-php/#avoiding-database-deadlocks
+ */
+
+// Prevent auto-connecting to DB, so 'set-db-isolation-level.php' can alter settings first.
+$conf['acquia_hosting_settings_autoconnect'] = FALSE;


### PR DESCRIPTION
Restores this functionality as I deleted the original rc branch. See #257 