### PR TITLE
reset patternlab reference 0.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ### Security
 
+## [2.0.9] - 2024-07-26
+### Changed
+- Revert the master branch to match 2.0.7
+
 ## [2.0.8] - 2024-07-25
 ### Changed
 - Revert `ecms_patternlab` to 0.7.5
@@ -1072,7 +1076,8 @@ RIGA-453: Updated migrate_tools to 6.0.3 [sa-contrib-2024-008](https://www.drupa
 ### Added
 - Initial Release of the site.
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/2.0.7...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/2.0.9...HEAD
+[2.0.9]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/2.0.8...2.0.9
 [2.0.8]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/2.0.7...2.0.8
 [2.0.7]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/2.0.6...2.0.7
 [2.0.6]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/2.0.5...2.0.6

--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
         "rhodeislandecms/ecms_profile": "1.0.5",
-        "state-of-rhode-island-ecms/ecms_patternlab": "0.7.5",
+        "state-of-rhode-island-ecms/ecms_patternlab": "0.7.8",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },
     "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e307fa3b3233450e7c2f2957cbd20f97",
+    "content-hash": "dc21879d1dc77afecc22af7b3452d68b",
     "packages": [
         {
             "name": "acquia/http-hmac-php",
@@ -16806,11 +16806,11 @@
         },
         {
             "name": "state-of-rhode-island-ecms/ecms_patternlab",
-            "version": "0.7.5",
+            "version": "0.7.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/State-of-Rhode-Island-eCMS/ecms_patternlab.git",
-                "reference": "a83a68fe131f7324eb9a04dc9b06b04c62d23caf"
+                "reference": "79aed50cb585c186f63ca4d0d2bddfd7119f6b3e"
             },
             "type": "pattern-lab",
             "license": [
@@ -16824,7 +16824,7 @@
                 }
             ],
             "description": "Pattern Lab for the State of Rhode Island's eCMS system",
-            "time": "2024-06-24T18:24:21+00:00"
+            "time": "2024-07-25T15:28:27+00:00"
         },
         {
             "name": "steverhoades/oauth2-openid-connect-server",


### PR DESCRIPTION
## Summary
Although version 2.0.8 was tagged, it was incomplete. We deployed version 2.0.7 to production. This PR updates the master branch to match the 2.0.7 tag.

