### PR TITLE
Switch from Ansible-based CI workflow to direct Actions workflow  V2

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -129,7 +129,9 @@ jobs:
       - name: Prepare distribution for deployment to Site Factory
         run: |
           vendor/bin/drush acsf-init --include="docroot/modules/contrib/acsf/acsf_init" --root="docroot" -y
-          cd docroot && ../vendor/bin/drush acsf-init-verify && cd ..
+          cd docroot
+          ../vendor/bin/drush acsf-init-verify
+          cd ..
 
   deploy:
     name: Deploy to Acquia

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -13,7 +13,7 @@ env:
   PHP_EXTENSIONS: 'gd, curl, mbstring, mysqli, opcache, xml, zip, apcu'
   PHP_TOOLS: 'composer'
   NODE_VERSION: '10.x'
-  DRUPAL_ARCHIVE_CONTENTS: 'config vendor docroot composer.json composer.lock'
+  DRUPAL_ARCHIVE_CONTENTS: 'config vendor docroot composer.json composer.lock, hooks'
 
 jobs:
   test:
@@ -111,6 +111,11 @@ jobs:
       - name: Install Node dependencies
         run: npm ci --no-fund --no-progress --production
 
+      - name: Prepare distribution for deployment to Site Factory
+        run: |
+          vendor/bin/drush acsf-init --include="docroot/modules/contrib/acsf/acsf_init" --root="docroot" -y
+          vendor/bin/drush --include=docroot/modules/contrib/acsf/acsf_init acsf-init-verify
+
       - name: Run Gulp
         run: gulp build
 
@@ -125,11 +130,6 @@ jobs:
         with:
           name: drupal
           path: drupal.tar.gz
-
-      - name: Prepare distribution for deployment to Site Factory
-        run: |
-          vendor/bin/drush acsf-init --include="docroot/modules/contrib/acsf/acsf_init" --root="docroot" -y
-          vendor/bin/drush --include=docroot/modules/contrib/acsf/acsf_init acsf-init-verify
 
   deploy:
     name: Deploy to Acquia

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -129,9 +129,7 @@ jobs:
       - name: Prepare distribution for deployment to Site Factory
         run: |
           vendor/bin/drush acsf-init --include="docroot/modules/contrib/acsf/acsf_init" --root="docroot" -y
-          cd docroot
-          ../vendor/bin/drush acsf-init-verify
-          cd ..
+          vendor/bin/drush acsf-init-verify
 
   deploy:
     name: Deploy to Acquia

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -13,7 +13,7 @@ env:
   PHP_EXTENSIONS: 'gd, curl, mbstring, mysqli, opcache, xml, zip, apcu'
   PHP_TOOLS: 'composer'
   NODE_VERSION: '10.x'
-  DRUPAL_ARCHIVE_CONTENTS: 'config vendor docroot composer.json composer.lock, hooks'
+  DRUPAL_ARCHIVE_CONTENTS: 'config vendor docroot composer.json composer.lock hooks'
 
 jobs:
   test:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -126,6 +126,11 @@ jobs:
           name: drupal
           path: drupal.tar.gz
 
+      - name: Prepare distribution for deployment to Site Factory
+        run: |
+          vendor/bin/drush acsf-init --include="docroot/modules/contrib/acsf/acsf_init" --root="docroot" -y
+          cd docroot && ./../vendor/bin/drush acsf-init-verify && cd ..
+
   deploy:
     name: Deploy to Acquia
     needs: [test, build]

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Prepare distribution for deployment to Site Factory
         run: |
           vendor/bin/drush acsf-init --include="docroot/modules/contrib/acsf/acsf_init" --root="docroot" -y
-          cd docroot && ./../vendor/bin/drush acsf-init-verify && cd ..
+          cd docroot && ../vendor/bin/drush acsf-init-verify && cd ..
 
   deploy:
     name: Deploy to Acquia

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Prepare distribution for deployment to Site Factory
         run: |
           vendor/bin/drush acsf-init --include="docroot/modules/contrib/acsf/acsf_init" --root="docroot" -y
-          vendor/bin/drush acsf-init-verify
+          vendor/bin/drush --include=docroot/modules/contrib/acsf/acsf_init acsf-init-verify
 
   deploy:
     name: Deploy to Acquia


### PR DESCRIPTION
## Summary
This swaps out our old Ansible-based CI workflow for a direct Actions workflow. This does not rely on Lando for the build process, which has become unreliable.

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | N/A
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | N/A
| Did you perform browser testing? | N/A
| Risk level | Low
| Relevant links | 
