### PR TITLE
Updated the secrets location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ### Fixed
 - Switched from Ansible-based CI workflow to direct Actions workflow
+- RIGA-544: Fix the missing secrets.php file.
 
 ### Security
 

--- a/factory-hooks/post-settings-php/secrets.php
+++ b/factory-hooks/post-settings-php/secrets.php
@@ -7,3 +7,9 @@ $secrets_file = sprintf('/mnt/files/%s.%s/secrets.settings.php', $_ENV['AH_SITE_
 if (file_exists($secrets_file)) {
   require $secrets_file;
 }
+
+$cloudNextSecretsFile = sprintf('%s/secrets.settings.php', $_ENV['HOME']);
+
+if (file_exists($cloudNextSecretsFile)) {
+  require $cloudNextSecretsFile;
+}


### PR DESCRIPTION
## Summary
The secrets.settings.php file was no longer loading. This updates the file location as [per the documentation](https://docs.acquia.com/secrets#section-secretssettingsphp-file).

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIGA-544](https://thinkoomph.jira.com/browse/RIGA-544)
