### PR TITLE
Prepare CHANGELOG for 2.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
-- Update the `ecms_profile` to 1.0.9
 
 ### Deprecated
 
@@ -21,6 +20,10 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Fixed
 
 ### Security
+
+## [2.1.3] - 2024-10-29
+### Changed
+- Update the `ecms_profile` to 1.0.9
 
 ## [2.1.2] - 2024-10-03
 ### Changed
@@ -1154,7 +1157,8 @@ RIGA-453: Updated migrate_tools to 6.0.3 [sa-contrib-2024-008](https://www.drupa
 ### Added
 - Initial Release of the site.
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/2.1.2...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/2.1.3...HEAD
+[2.1.3]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/2.1.2...2.1.3
 [2.1.2]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/2.1.1...2.1.2
 [2.1.1]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/2.1.0...2.1.1
 [2.1.0]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/2.0.9...2.1.0


### PR DESCRIPTION
## [2.1.3] - 2024-10-29
### Changed
- Update the `ecms_profile` to 1.0.9

[2.1.3]: https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/compare/2.1.2...2.1.3