### PR TITLE
Riga 566/fix patch for the feeds module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Deprecated
 
 ### Removed
+- RIGA-566: Removed an unnecessary patch to the feeds module.
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -179,9 +179,6 @@
                 "Re-save string config values as arrays": "patches/easy_breadcrumb-install.patch",
                 "3284123 - explode(): Passing null to parameter #2 ($string) of type string is deprecated": "https://www.drupal.org/files/issues/2022-09-20/fix_php81_explode-3284123-13.patch"
             },
-            "drupal/feeds": {
-                "3158678 - FetcherResult::checkFile() throws \\RuntimeException, which is never caught": "https://www.drupal.org/files/issues/2022-09-27/feeds-3158678-9-catch-runtime-errors.patch"
-            },
             "drupal/google_translator": {
                 "3387636 - Missing google_translator_disclaimer_title setting causes PHP 8.1 errors": "https://git.drupalcode.org/project/google_translator/-/merge_requests/3.diff"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d950733f6b63321961071b7bf2d81180",
+    "content-hash": "2deda82f504206b84b27cc1264491a89",
     "packages": [
         {
             "name": "acquia/http-hmac-php",
@@ -3536,7 +3536,7 @@
             ],
             "authors": [
                 {
-                    "name": "Centarro",
+                    "name": "centarro",
                     "homepage": "https://www.drupal.org/user/3661446"
                 },
                 {
@@ -3584,7 +3584,7 @@
             ],
             "authors": [
                 {
-                    "name": "Centarro",
+                    "name": "centarro",
                     "homepage": "https://www.drupal.org/user/3661446"
                 },
                 {
@@ -3626,7 +3626,7 @@
             ],
             "authors": [
                 {
-                    "name": "Centarro",
+                    "name": "centarro",
                     "homepage": "https://www.drupal.org/user/3661446"
                 },
                 {
@@ -3670,7 +3670,7 @@
             ],
             "authors": [
                 {
-                    "name": "Centarro",
+                    "name": "centarro",
                     "homepage": "https://www.drupal.org/user/3661446"
                 },
                 {
@@ -3784,7 +3784,7 @@
             ],
             "authors": [
                 {
-                    "name": "Centarro",
+                    "name": "centarro",
                     "homepage": "https://www.drupal.org/user/3661446"
                 },
                 {


### PR DESCRIPTION
## Summary
This removes a broken patch from the feeds module.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIGA-566](https://thinkoomph.jira.com/browse/RIGA-566)