### PR TITLE
Block user 1 on site install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Fixed
 
 ### Security
+- RIGA-565: Added post install script to block user/1.
 
 ## [2.1.3] - 2024-10-29
 ### Changed

--- a/factory-hooks/post-site-install/block-user-one.sh
+++ b/factory-hooks/post-site-install/block-user-one.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+#
+# Factory Hook: post-site-install
+#
+# This script will block user/1 after the site is installed.
+#
+# Usage: SCRIPTNAME site env db-role domain custom-arg1 custom-arg2 ...
+# Map the script inputs to convenient names.
+# Acquia hosting site / environment names
+site="$1"
+env="$2"
+
+# database role. (Not expected to be needed in most hook scripts.)
+db_role="$3"
+
+# The public domain name of the website.
+domain="$4"
+
+# Custom argument passed with the code update UI.
+# Custom argument.
+# custom_argument="$5"
+
+# The websites' document root can be derived from the site/env:
+docroot="/var/www/html/$site.$env/docroot"
+
+# Acquia recommends the following two practices:
+# 1. Hardcode the drush version.
+# 2. When running drush, provide the application + url, rather than relying
+#    on aliases. This can prevent some hard to trace problems.
+DRUSH_CMD="/var/www/html/$site.$env/vendor/bin/drush --verbose --root=$docroot --uri=https://$domain"
+
+# Ensures the default email address is ecms@notification.ri.gov.
+$DRUSH_CMD user:block --uid=1 >> /var/log/sites/${AH_SITE_NAME}/logs/$(hostname -s)/post-install-${domain}-$(date +"%Y-%m-%d").log
+


### PR DESCRIPTION
## Summary
This blocks user/1 for every new site that gets installed.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIGA-565](https://thinkoomph.jira.com/browse/RIGA-565)
