### PR TITLE
Fixed install script

### DIFF
--- a/factory-hooks/post-site-install/apply-recipes.sh
+++ b/factory-hooks/post-site-install/apply-recipes.sh
@@ -29,6 +29,8 @@ docroot="/var/www/html/$site.$env/docroot"
 #    on aliases. This can prevent some hard to trace problems.
 DRUSH_CMD="/var/www/html/$site.$env/vendor/bin/drush --verbose --root=$docroot --uri=https://$domain"
 
-# Apply the hub connection recipe to all new sites
+# Apply the hub connection requirements to all new sites
+$DRUSH_CMD pm:install ecms_api_publisher --yes  >> /var/log/sites/${AH_SITE_NAME}/logs/$(hostname -s)/post-install-${domain}-$(date +"%Y-%m-%d").log
+$DRUSH_CMD pm:install ecms_api_recipient --yes  >> /var/log/sites/${AH_SITE_NAME}/logs/$(hostname -s)/post-install-${domain}-$(date +"%Y-%m-%d").log
 $DRUSH_CMD recipe profiles/contrib/ecms_profile/ecms_base/recipes/ecms_api_press_release_publisher >> /var/log/sites/${AH_SITE_NAME}/logs/$(hostname -s)/post-install-${domain}-$(date +"%Y-%m-%d").log
 $DRUSH_CMD cache:rebuild


### PR DESCRIPTION
This fixes the post site install script to install the recipe requirements with drush before applying the recipe. This works around the environment being unable to connect and register with the hub.

[RIGA-512](https://thinkoomph.jira.com/browse/RIGA-605)