### PR TITLE
added patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIGA-670: Added D11 Patch: Migrate Process Trim
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -184,8 +184,8 @@
             "drupal/paragraphs": {
                 "3095959 - Paragraph type permissions conflicts with view unpublished paragraph permission": "https://www.drupal.org/files/issues/2019-11-22/paragraphs_type_permissions_view_unpublished_3095959-5.patch"
             },
-            "drupal/migrate_process_trim": {
-                "3288638 - Automated Drupal 10 compatibility fixes": "https://www.drupal.org/files/issues/2022-06-16/migrate_process_trim.2.0.x-dev.rector.patch"
+            "drupal_git/migrate_process_trim": {
+                "3288638 - Automated Drupal 11 compatibility fixes": "https://git.drupalcode.org/project/migrate_process_trim/-/merge_requests/1.patch"
             },
             "drush/drush": {
                 "Drush apply recipe": "https://patch-diff.githubusercontent.com/raw/drush-ops/drush/pull/5997.diff"


### PR DESCRIPTION
Added D11 Patch: Migrate Process Trim (migrate_process_trim)
[Automated Drupal 10, 11 compatibility fixes for Migrate Process Trim](https://www.drupal.org/project/migrate_process_trim/issues/3288638)

[RIGA-670](https://thinkoomph.jira.com/browse/RIGA-670)