### PR TITLE
Update Simple Oauth to ^6.0.7"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -143,9 +143,6 @@
             "drupal/paragraphs": {
                 "3095959 - Paragraph type permissions conflicts with view unpublished paragraph permission": "https://www.drupal.org/files/issues/2019-11-22/paragraphs_type_permissions_view_unpublished_3095959-5.patch"
             },
-            "drupal/simple_oauth": {
-                "3512143: 5.2.x -> 6.0.0 upgrade error": "patches/3512143-simple_oauth-5-6-upgrade.patch"
-            },
             "drush/drush": {
                 "Drush apply recipe": "https://patch-diff.githubusercontent.com/raw/drush-ops/drush/pull/5997.diff"
             }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4ef2606bac2f35b7c7e98faaf86358e3",
+    "content-hash": "29d461da4d3f8e0a4506fcd2eec2a6b9",
     "packages": [
         {
             "name": "acquia/http-hmac-php",
@@ -10387,17 +10387,17 @@
         },
         {
             "name": "drupal/simple_oauth",
-            "version": "6.0.0",
+            "version": "6.0.7",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/simple_oauth.git",
-                "reference": "6.0.0"
+                "reference": "6.0.7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/simple_oauth-6.0.0.zip",
-                "reference": "6.0.0",
-                "shasum": "a19c2ef0cbfae431af0e92ea5c89d7514cd7c238"
+                "url": "https://ftp.drupal.org/files/projects/simple_oauth-6.0.7.zip",
+                "reference": "6.0.7",
+                "shasum": "5b01712d56638fcf746b435b968f4cdb77e3c963"
             },
             "require": {
                 "drupal/consumers": "^1.17",
@@ -10413,8 +10413,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "6.0.0",
-                    "datestamp": "1741341101",
+                    "version": "6.0.7",
+                    "datestamp": "1761756257",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -10438,6 +10438,10 @@
                 {
                     "name": "e0ipso",
                     "homepage": "https://www.drupal.org/user/550110"
+                },
+                {
+                    "name": "kingdutch",
+                    "homepage": "https://www.drupal.org/user/1868952"
                 },
                 {
                     "name": "pcambra",


### PR DESCRIPTION
This pull request makes a minor update to the `composer.json` file by removing a patch for the `drupal/simple_oauth` module that addressed an upgrade error from version 5.2.x to 6.0.0. This likely means the patch is no longer needed, possibly due to an upstream fix or update.

- Removed the `3512143-simple_oauth-5-6-upgrade.patch` entry for the `drupal/simple_oauth` module from the `composer.json` patches section.

[RIGA-742](https://thinkoomph.jira.com/browse/riga-742)