### PR TITLE
Updated fast404 to be less aggressive

### DIFF
--- a/factory-hooks/post-settings-php/fast404.php
+++ b/factory-hooks/post-settings-php/fast404.php
@@ -5,4 +5,5 @@
  * Add settings for the Fast 404 module.
  */
 $settings['fast404_exts'] = '/^(?!\/robots)^(?!\/system\/files).*\.(txt|png|gif|jpe?g|css|js|ico|swf|flv|cgi|bat|pl|dll|exe|asp)$/i';
-$settings['fast404_not_found_exception'] = TRUE;
+$settings['fast404_not_found_exception'] = FALSE;
+$settings['fast404_path_check'] = FALSE;


### PR DESCRIPTION
## Summary
The fast404 module was too aggressive, wiping out custom error pages. This updates settings to only fast404 for server files and use Drupal defaults for possible Drupal paths.

[RIGA-810](https://thinkoomph.jira.com/browse/RIGA-810)