### PR TITLE
Security update for drupal/paragraphs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "nnnick/chartjs": "^4.4",
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
-        "rhodeislandecms/ecms_profile": "2.0.6",
+        "rhodeislandecms/ecms_profile": "dev-rc/2.0.7",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },
     "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -8840,17 +8840,17 @@
         },
         {
             "name": "drupal/paragraphs",
-            "version": "1.20.0",
+            "version": "1.21.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/paragraphs.git",
-                "reference": "8.x-1.20"
+                "reference": "8.x-1.21"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/paragraphs-8.x-1.20.zip",
-                "reference": "8.x-1.20",
-                "shasum": "68051cc8c025aa3f62fd44a219d158361928a4ad"
+                "url": "https://ftp.drupal.org/files/projects/paragraphs-8.x-1.21.zip",
+                "reference": "8.x-1.21",
+                "shasum": "5638fab65f5c9cf954ef369411b2ee64d41e21f9"
             },
             "require": {
                 "drupal/core": "^10.3 || ^11",
@@ -8863,7 +8863,7 @@
                 "drupal/entity_usage": "2.x-dev",
                 "drupal/feeds": "^3",
                 "drupal/field_group": "3.x-dev",
-                "drupal/inline_entity_form": "3.x-dev",
+                "drupal/inline_entity_form": "^3",
                 "drupal/paragraphs-paragraphs_library": "*",
                 "drupal/replicate": "1.x-dev",
                 "drupal/search_api": "^1",
@@ -8875,8 +8875,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.20",
-                    "datestamp": "1767269542",
+                    "version": "8.x-1.21",
+                    "datestamp": "1782326108",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6ee69366abe538d4ba450bd4806165ae",
+    "content-hash": "28511898d2c59dc303a34a03c70d9f92",
     "packages": [
         {
             "name": "acquia/http-hmac-php",
@@ -2979,6 +2979,55 @@
             "homepage": "https://www.drupal.org/project/book",
             "support": {
                 "source": "https://git.drupalcode.org/project/book"
+            }
+        },
+        {
+            "name": "drupal/cache_control_override",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/cache_control_override.git",
+                "reference": "2.0.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/cache_control_override-2.0.1.zip",
+                "reference": "2.0.1",
+                "shasum": "383f85e313296f2da1315a0b58f82e389f903718"
+            },
+            "require": {
+                "drupal/core": "^10.2 || ^11",
+                "php": ">=8.1"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.1",
+                    "datestamp": "1724222747",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "asgorobets",
+                    "homepage": "https://www.drupal.org/user/1399950"
+                },
+                {
+                    "name": "dpi",
+                    "homepage": "https://www.drupal.org/user/81431"
+                }
+            ],
+            "description": "Override page Cache-Control header based on bubbled cacheability metadata.",
+            "homepage": "https://www.drupal.org/project/cache_control_override",
+            "support": {
+                "source": "https://git.drupalcode.org/project/cache_control_override"
             }
         },
         {
@@ -16524,11 +16573,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "2.0.6",
+            "version": "dev-rc/2.0.7",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "c392f94ae89025e2a9debbccaa8f0685714ab887"
+                "reference": "8f7be4597df08875c35a95365fa6f7860169555f"
             },
             "require": {
                 "composer/installers": "^1.9 || ^2.0",
@@ -16548,6 +16597,7 @@
                 "drupal/better_exposed_filters": "^7.0.5",
                 "drupal/bigmenu": "^2.0@RC",
                 "drupal/book": "^1.0.0",
+                "drupal/cache_control_override": "^2.0",
                 "drupal/captcha": "^2.0",
                 "drupal/classy": "^2.0",
                 "drupal/commerce": "^3.1",
@@ -16690,7 +16740,7 @@
                         "3288638 - Automated Drupal 11 compatibility fixes": "https://gist.githubusercontent.com/pfrilling/0c65512c56ade5d240d7af025ae4938a/raw/0c2b363a9ab493ffccf10ce10c6ade1215b689e0/gistfile1.txt"
                     },
                     "drupal/paragraphs": {
-                        "3090200 - Paragraphs do not render: access check for 'view' fail when using layout builder": "https://www.drupal.org/files/issues/2020-07-08/access-controll-issue-3090200-22.patch",
+                        "3090200 - Paragraph access check uses default revision instead of referencing revision": "https://www.drupal.org/files/issues/2026-07-06/paragraphs-parent-access-block-content-skip-3090200-97.patch",
                         "2887353 - Paragraph Translation Sync": "https://gist.githubusercontent.com/pfrilling/87798df963feab76fbef5f4abe65fa10/raw/76c8f8cd06574b16b7da71ea2a0c1708d6d21871/paragraphs-translation-sync-2887353-60.patch"
                     },
                     "drupal/seckit": {
@@ -16724,7 +16774,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2026-05-27T18:38:52+00:00"
+            "time": "2026-07-07T15:57:49+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",
@@ -25540,7 +25590,8 @@
     "stability-flags": {
         "drupal/config_update": 15,
         "drupal/feeds": 10,
-        "drupal/jsonapi_extras": 20
+        "drupal/jsonapi_extras": 20,
+        "rhodeislandecms/ecms_profile": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,


### PR DESCRIPTION
Security Updates:
paragraphs (1.20.0) to paragraphs (1.21.0)
[RIGA-870](https://thinkoomph.jira.com/browse/RIGA-870)