### PR TITLE
rc/3.0.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "nnnick/chartjs": "^4.4",
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
-        "rhodeislandecms/ecms_profile": "dev-rc/2.0.8",
+        "rhodeislandecms/ecms_profile": "dev-rc/2.0.9",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },
     "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -16966,7 +16966,7 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "9011c6f987b759994a687d20f79e54444f6a324f"
+                "reference": "ee83d2bd7cefe16984d34f57375d52f85d5a6d91"
             },
             "require": {
                 "composer/installers": "^1.9 || ^2.0",
@@ -17164,7 +17164,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2026-07-28T15:28:42+00:00"
+            "time": "2026-07-30T14:51:04+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -16966,7 +16966,7 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "a671e9516e9c18bfff24f85967f015b216219fe4"
+                "reference": "85f8f9107c63513624a50e00d04697836561ba37"
             },
             "require": {
                 "composer/installers": "^1.9 || ^2.0",
@@ -17164,7 +17164,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2026-07-31T16:33:58+00:00"
+            "time": "2026-07-31T18:31:11+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -16966,7 +16966,7 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "50f21fd797865e52fa6d4c3b83a6b29661f3a232"
+                "reference": "a671e9516e9c18bfff24f85967f015b216219fe4"
             },
             "require": {
                 "composer/installers": "^1.9 || ^2.0",
@@ -17164,7 +17164,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2026-07-31T14:09:30+00:00"
+            "time": "2026-07-31T16:33:58+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e308c7042dfdc893a0e002a6320fdc34",
+    "content-hash": "80d0f83624b58b0da6dfd751b280cf73",
     "packages": [
         {
             "name": "acquia/http-hmac-php",
@@ -16962,11 +16962,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "dev-rc/2.0.8",
+            "version": "dev-rc/2.0.9",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "ea48d4c61b84b010d42d81b464850481387e8293"
+                "reference": "9011c6f987b759994a687d20f79e54444f6a324f"
             },
             "require": {
                 "composer/installers": "^1.9 || ^2.0",
@@ -17164,7 +17164,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2026-07-17T18:07:38+00:00"
+            "time": "2026-07-28T15:28:42+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -16966,7 +16966,7 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "ee83d2bd7cefe16984d34f57375d52f85d5a6d91"
+                "reference": "50f21fd797865e52fa6d4c3b83a6b29661f3a232"
             },
             "require": {
                 "composer/installers": "^1.9 || ^2.0",
@@ -17164,7 +17164,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2026-07-30T14:51:04+00:00"
+            "time": "2026-07-31T14:09:30+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",


### PR DESCRIPTION
This pull request updates the version constraint for the `rhodeislandecms/ecms_profile` dependency in the `composer.json` file to use the `dev-rc/2.0.9` branch instead of the fixed `2.0.7` version. This allows the project to track the latest changes in the release candidate branch for `ecms_profile`.