### PR TITLE
Fixed webform export directory

### DIFF
--- a/factory-hooks/post-settings-php/temp-file-path.php
+++ b/factory-hooks/post-settings-php/temp-file-path.php
@@ -12,3 +12,9 @@ $settings['file_temp_path'] = '/mnt/tmp/' . $_ENV['AH_SITE_GROUP'] . '.' . $_ENV
 
 // Setting from workaround in Feeds issue: 'https://www.drupal.org/project/feeds/issues/2912130'.
 $config['system.file']['path']['temporary'] = '/mnt/tmp/' . $_ENV['AH_SITE_GROUP'] . '.' . $_ENV['AH_SITE_ENVIRONMENT'];
+
+// Use private file system for webform exports to ensure files are accessible
+// across all cluster nodes on ACSF. Without this, PDF files are written to the
+// local /tmp on one server and missing when subsequent batch requests hit a
+// different server. See: https://www.drupal.org/project/webform/issues/3284953
+$config['webform.settings']['export']['temp_directory'] = 'private://webform_exports';


### PR DESCRIPTION
This pull request makes an important configuration change to address file consistency issues in a clustered environment. It ensures that webform export files are stored in a location accessible to all nodes, preventing missing files during batch operations.

Configuration and file storage improvements:

* Updated the `webform.settings` export configuration to use the private file system (`private://webform_exports`) for temporary export files, ensuring accessibility across all cluster nodes and preventing missing PDF files in multi-server environments.

[RIGA-878](https://thinkoomph.jira.com/browse/RIGA-878)