### PR TITLE
Updated form download path to not use URI, but system path

### DIFF
--- a/factory-hooks/post-settings-php/temp-file-path.php
+++ b/factory-hooks/post-settings-php/temp-file-path.php
@@ -17,4 +17,27 @@ $config['system.file']['path']['temporary'] = '/mnt/tmp/' . $_ENV['AH_SITE_GROUP
 // across all cluster nodes on ACSF. Without this, PDF files are written to the
 // local /tmp on one server and missing when subsequent batch requests hit a
 // different server. See: https://www.drupal.org/project/webform/issues/3284953
-$config['webform.settings']['export']['temp_directory'] = 'private://webform_exports';
+//
+// Webform hands this value straight to fopen() and to ZipArchive::open(), and
+// ZipArchive cannot read stream wrappers, so this must be a real filesystem
+// path rather than a 'private://' URI.
+//
+// ACSF sets file_private_path per site before the post-settings-php hooks run.
+// Fall back to rebuilding the path from the site's ACSF database name, which
+// is the per-site directory name under sites/g/files-private.
+$ecms_private_path = $settings['file_private_path'] ?? '';
+
+if (empty($ecms_private_path) && !empty($GLOBALS['gardens_site_settings']['conf']['acsf_db_name'])) {
+  $ecms_private_path = sprintf(
+    '/mnt/files/%s.%s/sites/g/files-private/%s',
+    $_ENV['AH_SITE_GROUP'],
+    $_ENV['AH_SITE_ENVIRONMENT'],
+    $GLOBALS['gardens_site_settings']['conf']['acsf_db_name']
+  );
+}
+
+if (!empty($ecms_private_path)) {
+  $config['webform.settings']['export']['temp_directory'] = rtrim($ecms_private_path, '/') . '/webform_exports';
+}
+
+unset($ecms_private_path);


### PR DESCRIPTION
This pull request updates how the temporary export directory for Webform is set in `temp-file-path.php`. The main goal is to ensure that the export directory uses a real filesystem path (not a stream wrapper like `private://`), which is required for compatibility with `ZipArchive`. It also adds logic to reliably determine the correct private file path in ACSF environments by reconstructing it if necessary.

**Webform export temp directory handling:**

* Replaces the use of a `private://` URI with a real filesystem path for the `webform.settings` export `temp_directory`, ensuring compatibility with `ZipArchive` and `fopen()`.
* Adds logic to reconstruct the private file path from ACSF environment variables and site settings if it is not already set, improving reliability in multi-site and cloud environments.

[RIGA-885](https://thinkoomph.jira.com/browse/RIGA-885)