### PR TITLE
Rc/3.0.14

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "nnnick/chartjs": "^4.4",
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
-        "rhodeislandecms/ecms_profile": "2.0.9",
+        "rhodeislandecms/ecms_profile": "dev-rc/2.0.10",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },
     "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -5234,17 +5234,17 @@
         },
         {
             "name": "drupal/externalauth",
-            "version": "2.0.11",
+            "version": "2.0.13",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/externalauth.git",
-                "reference": "2.0.11"
+                "reference": "2.0.13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/externalauth-2.0.11.zip",
-                "reference": "2.0.11",
-                "shasum": "f0f1eb7a386efda1066a392fd960792ac92386d6"
+                "url": "https://ftp.drupal.org/files/projects/externalauth-2.0.13.zip",
+                "reference": "2.0.13",
+                "shasum": "7daa85bd385c850e1a9c7a92fad15f394e7891b9"
             },
             "require": {
                 "drupal/core": "^10.1 || ^11"
@@ -5252,8 +5252,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.11",
-                    "datestamp": "1772135408",
+                    "version": "2.0.13",
+                    "datestamp": "1786557339",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5269,14 +5269,6 @@
                     "name": "Sven Decabooter",
                     "homepage": "https://www.drupal.org/u/svendecabooter",
                     "role": "Maintainer"
-                },
-                {
-                    "name": "snufkin",
-                    "homepage": "https://www.drupal.org/user/58645"
-                },
-                {
-                    "name": "svendecabooter",
-                    "homepage": "https://www.drupal.org/user/35369"
                 }
             ],
             "description": "Helper module to authenticate users using an external site / service and storing identification details",
@@ -25273,16 +25265,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -25348,7 +25340,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "staabm/side-effects-detector",

--- a/composer.lock
+++ b/composer.lock
@@ -16958,7 +16958,7 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "74b633a1b3f5d0a3d28540089dc35ec92c51ae61"
+                "reference": "ffef006244ccad0601f8985e60e503657bddbde1"
             },
             "require": {
                 "composer/installers": "^1.9 || ^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "de4ae800219777fc508be8eb6fe5c514",
+    "content-hash": "faafdf7cbc3294bbf072181cd6f0a392",
     "packages": [
         {
             "name": "acquia/http-hmac-php",
@@ -16954,11 +16954,11 @@
         },
         {
             "name": "rhodeislandecms/ecms_profile",
-            "version": "2.0.9",
+            "version": "dev-rc/2.0.10",
             "source": {
                 "type": "git",
                 "url": "git@github.com:State-of-Rhode-Island-eCMS/ecms_profile.git",
-                "reference": "33de715409f8913d90c4676d7f8f2691615f23da"
+                "reference": "74b633a1b3f5d0a3d28540089dc35ec92c51ae61"
             },
             "require": {
                 "composer/installers": "^1.9 || ^2.0",
@@ -17156,7 +17156,7 @@
                 }
             ],
             "description": "Drupal installation profile for the State of Rhode Island's eCMS system",
-            "time": "2026-08-03T19:16:13+00:00"
+            "time": "2026-08-19T17:41:43+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",
@@ -25956,7 +25956,8 @@
     "stability-flags": {
         "drupal/config_update": 15,
         "drupal/feeds": 10,
-        "drupal/jsonapi_extras": 20
+        "drupal/jsonapi_extras": 20,
+        "rhodeislandecms/ecms_profile": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/factory-hooks/post-settings-php/temp-file-path.php
+++ b/factory-hooks/post-settings-php/temp-file-path.php
@@ -17,4 +17,27 @@ $config['system.file']['path']['temporary'] = '/mnt/tmp/' . $_ENV['AH_SITE_GROUP
 // across all cluster nodes on ACSF. Without this, PDF files are written to the
 // local /tmp on one server and missing when subsequent batch requests hit a
 // different server. See: https://www.drupal.org/project/webform/issues/3284953
-$config['webform.settings']['export']['temp_directory'] = 'private://webform_exports';
+//
+// Webform hands this value straight to fopen() and to ZipArchive::open(), and
+// ZipArchive cannot read stream wrappers, so this must be a real filesystem
+// path rather than a 'private://' URI.
+//
+// ACSF sets file_private_path per site before the post-settings-php hooks run.
+// Fall back to rebuilding the path from the site's ACSF database name, which
+// is the per-site directory name under sites/g/files-private.
+$ecms_private_path = $settings['file_private_path'] ?? '';
+
+if (empty($ecms_private_path) && !empty($GLOBALS['gardens_site_settings']['conf']['acsf_db_name'])) {
+  $ecms_private_path = sprintf(
+    '/mnt/files/%s.%s/sites/g/files-private/%s',
+    $_ENV['AH_SITE_GROUP'],
+    $_ENV['AH_SITE_ENVIRONMENT'],
+    $GLOBALS['gardens_site_settings']['conf']['acsf_db_name']
+  );
+}
+
+if (!empty($ecms_private_path)) {
+  $config['webform.settings']['export']['temp_directory'] = rtrim($ecms_private_path, '/') . '/webform_exports';
+}
+
+unset($ecms_private_path);


### PR DESCRIPTION
This pull request updates a package dependency and improves the configuration logic for temporary file storage used by Webform exports. The main focus is to ensure that the export directory is always set to a valid filesystem path, accommodating different hosting environments.

**Dependency update:**

* Updated the `rhodeislandecms/ecms_profile` dependency in `composer.json` to use the `dev-rc/2.0.10` branch instead of the fixed `2.0.9` version.

**Configuration improvements for Webform exports:**

* Enhanced the logic in `factory-hooks/post-settings-php/temp-file-path.php` to reliably set the `webform.settings` export temporary directory to a real filesystem path. This includes:
  - Adding a fallback mechanism to reconstruct the private file path from ACSF environment variables and settings if it is not already set.
  - Ensuring the path is compatible with `fopen()` and `ZipArchive::open()` by avoiding the use of stream wrappers like `private://`.
  - Cleaning up by unsetting the temporary variable used for path construction.